### PR TITLE
Add Chrome extension to send YouTube transcripts to ChatGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# YouTube Transcript Summarizer
+
+This Chrome extension adds a "Summarize with ChatGPT" button to YouTube video pages. When clicked, the extension gathers the video's transcript (if one is available) and opens ChatGPT in a new tab with a pre-formatted prompt that requests a summary of the video.
+
+## Features
+
+- Injects a button into the YouTube video action bar.
+- Retrieves the video transcript using the available caption tracks.
+- Opens ChatGPT in a new tab and pastes a structured prompt for summarization.
+- Retries the prompt injection if the ChatGPT interface is not immediately ready.
+
+## Installation
+
+1. Clone or download this repository.
+2. Open **chrome://extensions** in Google Chrome and enable **Developer mode**.
+3. Click **Load unpacked** and select the folder containing the extension files (`manifest.json`, `background.js`, and `contentScript.js`).
+4. Navigate to a YouTube video that has captions available. A "Summarize with ChatGPT" button should appear alongside the other video actions.
+5. Click the button to open ChatGPT with the transcript ready to summarize.
+
+## Notes
+
+- The extension requires access to `https://www.youtube.com/*` to read transcripts and `https://chat.openai.com/*` to open ChatGPT.
+- For videos without transcripts, the extension will notify you that a transcript is unavailable.
+- If you are not logged in to ChatGPT, you may need to log in before the prompt appears. The extension will retry several times while the ChatGPT interface loads.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,135 @@
+const pendingPrompts = new Map();
+const MAX_INJECTION_ATTEMPTS = 10;
+const RETRY_DELAY_MS = 1000;
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type === 'openChatGPT' && typeof message.prompt === 'string') {
+    chrome.tabs.create({ url: 'https://chat.openai.com/' }, (tab) => {
+      if (tab?.id !== undefined) {
+        pendingPrompts.set(tab.id, { prompt: message.prompt, attempts: 0 });
+      }
+    });
+    sendResponse({ status: 'opening' });
+    return true;
+  }
+  return false;
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  const pending = pendingPrompts.get(tabId);
+  if (!pending) {
+    return;
+  }
+
+  const updatedUrl = changeInfo.url || tab.url;
+  if (!updatedUrl?.startsWith('https://chat.openai.com/')) {
+    return;
+  }
+
+  if (changeInfo.status === 'complete' || changeInfo.url) {
+    attemptPromptInjection(tabId);
+  }
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  pendingPrompts.delete(tabId);
+});
+
+const attemptPromptInjection = (tabId) => {
+  const pending = pendingPrompts.get(tabId);
+  if (!pending) {
+    return;
+  }
+
+  if (pending.attempts >= MAX_INJECTION_ATTEMPTS) {
+    console.warn('Max prompt injection attempts reached for tab', tabId);
+    pendingPrompts.delete(tabId);
+    return;
+  }
+
+  pending.attempts += 1;
+
+  chrome.scripting
+    .executeScript({
+      target: { tabId },
+      world: 'MAIN',
+      func: injectPrompt,
+      args: [pending.prompt]
+    })
+    .then((results) => {
+      const [result] = results || [];
+      if (result?.result) {
+        pendingPrompts.delete(tabId);
+      } else {
+        scheduleRetry(tabId);
+      }
+    })
+    .catch((error) => {
+      console.error('Failed to inject prompt:', error);
+      pendingPrompts.delete(tabId);
+    });
+};
+
+const scheduleRetry = (tabId) => {
+  const pending = pendingPrompts.get(tabId);
+  if (!pending) {
+    return;
+  }
+
+  if (pending.attempts >= MAX_INJECTION_ATTEMPTS) {
+    console.warn('Retry limit reached before scheduling for tab', tabId);
+    pendingPrompts.delete(tabId);
+    return;
+  }
+
+  setTimeout(() => {
+    const currentPending = pendingPrompts.get(tabId);
+    if (!currentPending) {
+      return;
+    }
+
+    chrome.tabs.get(tabId, (tab) => {
+      if (chrome.runtime.lastError) {
+        pendingPrompts.delete(tabId);
+        return;
+      }
+
+      if (tab?.url?.startsWith('https://chat.openai.com/')) {
+        attemptPromptInjection(tabId);
+      }
+    });
+  }, RETRY_DELAY_MS);
+};
+
+function injectPrompt(prompt) {
+  const findTextArea = () => {
+    const selectors = [
+      'textarea#prompt-textarea',
+      'textarea[data-id="root"]',
+      'textarea[data-id="prompt-textarea"]',
+      'textarea[placeholder*="Send a message"]',
+      'form textarea'
+    ];
+
+    for (const selector of selectors) {
+      const element = document.querySelector(selector);
+      if (element) {
+        return element;
+      }
+    }
+
+    return null;
+  };
+
+  const textArea = findTextArea();
+  if (!textArea) {
+    console.warn('ChatGPT text area not found.');
+    return false;
+  }
+
+  textArea.focus();
+  textArea.value = prompt;
+  const inputEvent = new Event('input', { bubbles: true });
+  textArea.dispatchEvent(inputEvent);
+  return true;
+}

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,219 @@
+const BUTTON_ID = 'ytlm-summarize-btn';
+const BUTTON_LABEL_DEFAULT = 'Summarize with ChatGPT';
+const BUTTON_LABEL_LOADING = 'Fetching transcript…';
+const BUTTON_LABEL_OPENING = 'Opening ChatGPT…';
+
+const addButtonIfNeeded = () => {
+  if (document.getElementById(BUTTON_ID)) {
+    return;
+  }
+
+  const container = document.querySelector('#top-row #actions #top-level-buttons-computed');
+  const fallbackContainer = document.querySelector('#top-level-buttons-computed');
+  const targetContainer = container || fallbackContainer;
+
+  if (!targetContainer) {
+    return;
+  }
+
+  const button = document.createElement('button');
+  button.id = BUTTON_ID;
+  button.type = 'button';
+  button.textContent = BUTTON_LABEL_DEFAULT;
+  button.className = 'yt-spec-button-shape-next yt-spec-button-shape-next--tonal yt-spec-button-shape-next--size-m';
+  button.style.marginLeft = '8px';
+  button.addEventListener('click', onButtonClick);
+  targetContainer.appendChild(button);
+};
+
+const onButtonClick = async () => {
+  const button = document.getElementById(BUTTON_ID);
+  if (!button) {
+    return;
+  }
+
+  button.disabled = true;
+  button.textContent = BUTTON_LABEL_LOADING;
+
+  try {
+    const transcript = await fetchTranscript();
+    if (!transcript) {
+      alert('Transcript unavailable for this video.');
+      button.textContent = BUTTON_LABEL_DEFAULT;
+      button.disabled = false;
+      return;
+    }
+
+    const titleElement = document.querySelector('h1.ytd-watch-metadata') || document.querySelector('h1.title');
+    const title = titleElement ? titleElement.innerText.trim() : document.title;
+    const prompt = buildPrompt({
+      title,
+      url: window.location.href,
+      transcript
+    });
+
+    if (!chrome?.runtime?.sendMessage) {
+      console.error('chrome.runtime.sendMessage is unavailable.');
+      alert('Unable to communicate with the extension background script.');
+      button.textContent = BUTTON_LABEL_DEFAULT;
+      button.disabled = false;
+      return;
+    }
+
+    button.textContent = BUTTON_LABEL_OPENING;
+    chrome.runtime.sendMessage({ type: 'openChatGPT', prompt }, () => {
+      if (chrome.runtime.lastError) {
+        console.error('Failed to open ChatGPT tab', chrome.runtime.lastError);
+        alert('Unable to open ChatGPT. Check extension permissions.');
+      }
+
+      button.textContent = BUTTON_LABEL_DEFAULT;
+      button.disabled = false;
+    });
+  } catch (error) {
+    console.error('Failed to fetch transcript', error);
+    alert('An error occurred while fetching the transcript. See the console for details.');
+    button.textContent = BUTTON_LABEL_DEFAULT;
+    button.disabled = false;
+  }
+};
+
+const buildPrompt = ({ title, url, transcript }) => {
+  const trimmedTranscript = transcript.trim();
+  return [
+    'You are an expert note taker. Please summarize the following YouTube video transcript.',
+    '',
+    `Title: ${title}`,
+    `URL: ${url}`,
+    '',
+    'Instructions:',
+    '1. Provide a concise overview in 2-3 sentences.',
+    '2. List the main takeaways as bullet points.',
+    '3. Include any actionable steps separately if applicable.',
+    '',
+    'Transcript:',
+    trimmedTranscript
+  ].join('\n');
+};
+
+const fetchTranscript = async () => {
+  const playerResponse = getPlayerResponse();
+  const captionTracks = playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+
+  if (!captionTracks || captionTracks.length === 0) {
+    return null;
+  }
+
+  let track = captionTracks.find((item) => !item.kind || item.kind !== 'asr');
+  if (!track) {
+    track = captionTracks[0];
+  }
+
+  const transcriptUrl = track.baseUrl.includes('&fmt=') ? track.baseUrl : `${track.baseUrl}&fmt=json3`;
+  const response = await fetch(transcriptUrl);
+  if (!response.ok) {
+    throw new Error(`Transcript request failed with status ${response.status}`);
+  }
+
+  const body = await response.text();
+
+  try {
+    const data = JSON.parse(body);
+    const transcriptFromJson = parseJsonTranscript(data);
+    if (transcriptFromJson) {
+      return transcriptFromJson;
+    }
+  } catch (error) {
+    console.debug('Transcript JSON parsing failed, attempting XML fallback.', error);
+  }
+
+  return parseXmlTranscript(body);
+};
+
+const parseJsonTranscript = (data) => {
+  if (!data?.events) {
+    return null;
+  }
+
+  const parts = [];
+  for (const event of data.events) {
+    if (!event.segs) {
+      continue;
+    }
+
+    const text = event.segs.map((seg) => seg.utf8).join('');
+    const cleaned = text.replace(/\s+/g, ' ').trim();
+    if (cleaned) {
+      parts.push(cleaned);
+    }
+  }
+
+  return parts.join(' ');
+};
+
+const parseXmlTranscript = (xmlText) => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xmlText, 'text/xml');
+  const textNodes = Array.from(doc.getElementsByTagName('text'));
+
+  if (textNodes.length === 0) {
+    return null;
+  }
+
+  const parts = textNodes
+    .map((node) => node.textContent?.replace(/\s+/g, ' ').trim())
+    .filter((value) => Boolean(value));
+
+  return parts.join(' ');
+};
+
+const getPlayerResponse = () => {
+  if (window.ytInitialPlayerResponse) {
+    return window.ytInitialPlayerResponse;
+  }
+
+  const watchFlexy = document.querySelector('ytd-watch-flexy');
+  if (watchFlexy?.playerResponse) {
+    return watchFlexy.playerResponse;
+  }
+
+  const playerElement = document.querySelector('ytd-player');
+  const player = playerElement?.player_ || playerElement;
+
+  if (player?.getPlayerResponse) {
+    try {
+      return player.getPlayerResponse();
+    } catch (error) {
+      console.warn('Failed to retrieve player response from player object.', error);
+    }
+  }
+
+  if (playerElement?.getPlayerResponse) {
+    try {
+      return playerElement.getPlayerResponse();
+    } catch (error) {
+      console.warn('Failed to retrieve player response from player element.', error);
+    }
+  }
+
+  if (typeof window.ytplayer !== 'undefined' && window.ytplayer?.config?.args?.player_response) {
+    try {
+      return JSON.parse(window.ytplayer.config.args.player_response);
+    } catch (error) {
+      console.warn('Failed to parse player response from ytplayer config.', error);
+    }
+  }
+
+  return null;
+};
+
+const observer = new MutationObserver(() => addButtonIfNeeded());
+observer.observe(document.body, { childList: true, subtree: true });
+
+window.addEventListener('yt-navigate-finish', () => {
+  setTimeout(() => {
+    addButtonIfNeeded();
+  }, 1000);
+});
+
+addButtonIfNeeded();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,27 @@
+{
+  "manifest_version": 3,
+  "name": "YouTube Transcript Summarizer",
+  "version": "1.0.0",
+  "description": "Adds a button to YouTube videos to send the transcript to ChatGPT for summarization.",
+  "permissions": [
+    "tabs",
+    "scripting"
+  ],
+  "host_permissions": [
+    "https://www.youtube.com/*",
+    "https://chat.openai.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.youtube.com/watch*"],
+      "js": ["contentScript.js"],
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_title": "YouTube Transcript Summarizer"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Manifest V3 Chrome extension that injects a ChatGPT summarization button on YouTube videos
- implement transcript retrieval, prompt building, and ChatGPT tab automation with retries
- document installation and usage instructions in the README

## Testing
- not run (extension code)


------
https://chatgpt.com/codex/tasks/task_e_68cda13d3af08320843d6a9e16807ce8