### PR TITLE
Improve consent form detection in watch page fetch

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -789,11 +789,12 @@ const fetchWatchPageHtml = async (videoId) => {
 
     let html = await response.text();
 
-    if (html.includes('action="https://consent.youtube.com/s"')) {
-      const match = html.match(/name="v" value="(.*?)"/);
-      if (match?.[1]) {
+    const consentFormDetected = /<form[^>]*action="https:\/\/consent\.youtube\.com\/s(?:\?[^"]*)?"/i.test(html);
+    if (consentFormDetected) {
+      const consentValueMatch = html.match(/name="v" value="(.*?)"/);
+      if (consentValueMatch?.[1]) {
         try {
-          document.cookie = `CONSENT=YES+${match[1]}; Domain=.youtube.com; Path=/; Secure`;
+          document.cookie = `CONSENT=YES+${consentValueMatch[1]}; Domain=.youtube.com; Path=/; Secure`;
         } catch (cookieError) {
           console.debug('Failed to persist consent cookie for transcript fallback.', cookieError);
         }


### PR DESCRIPTION
## Summary
- detect consent forms on watch pages by matching any https://consent.youtube.com/s form action
- gate the consent cookie retry logic on the detected form so the fallback refetches only when needed

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce00ae60d48320925c12b1a90d0d73