### PR TITLE
Fix entity decoding order

### DIFF
--- a/background.js
+++ b/background.js
@@ -288,6 +288,10 @@ function decodeHtmlEntities(text) {
 
   let decoded = text;
 
+  decoded = decoded.replace(/&amp;/gi, '&');
+  decoded = decoded.replace(/&lt;/gi, '<');
+  decoded = decoded.replace(/&gt;/gi, '>');
+
   const whitespaceEntityPatterns = [
     /&nbsp;/gi,
     /&#160;/gi,
@@ -309,17 +313,20 @@ function decodeHtmlEntities(text) {
     decoded = decoded.replace(pattern, ' ');
   }
 
-  decoded = decoded.replace(/&amp;/gi, '&');
-  decoded = decoded.replace(/&lt;/gi, '<');
-  decoded = decoded.replace(/&gt;/gi, '>');
-
   return decoded;
 }
 
 (() => {
-  const sampleHtml = '<div>Please&nbsp;Sign&nbsp;In</div>';
-  if (!detectGlaspSignInPrompt(sampleHtml)) {
-    console.warn('Sign-in detection failed for HTML entity sample.');
+  const samples = [
+    '<div>Please&nbsp;Sign&nbsp;In</div>',
+    '<div>Please&amp;nbsp;Sign&amp;nbsp;In</div>'
+  ];
+
+  for (const sample of samples) {
+    if (!detectGlaspSignInPrompt(sample)) {
+      console.warn('Sign-in detection failed for HTML entity sample:', sample);
+      break;
+    }
   }
 })();
 


### PR DESCRIPTION
## Summary
- ensure general HTML entity decoding runs before whitespace replacements so `&amp;nbsp;` collapses to plain spaces
- extend the sign-in detection self-check to cover HTML with encoded whitespace entities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf742b60c88320938b544dec75eb6d