### PR TITLE
Handle numeric ampersand entities in Glasp sign-in detection

### DIFF
--- a/background.js
+++ b/background.js
@@ -289,6 +289,14 @@ function decodeHtmlEntities(text) {
   let decoded = text;
 
   decoded = decoded.replace(/&amp;/gi, '&');
+  decoded = decoded.replace(/&#(\d+);/gi, (match, value) => {
+    const codePoint = Number.parseInt(value, 10);
+    return codePoint === 38 ? '&' : match;
+  });
+  decoded = decoded.replace(/&#x([0-9a-f]+);/gi, (match, value) => {
+    const codePoint = Number.parseInt(value, 16);
+    return codePoint === 0x26 ? '&' : match;
+  });
   decoded = decoded.replace(/&lt;/gi, '<');
   decoded = decoded.replace(/&gt;/gi, '>');
 
@@ -319,7 +327,9 @@ function decodeHtmlEntities(text) {
 (() => {
   const samples = [
     '<div>Please&nbsp;Sign&nbsp;In</div>',
-    '<div>Please&amp;nbsp;Sign&amp;nbsp;In</div>'
+    '<div>Please&amp;nbsp;Sign&amp;nbsp;In</div>',
+    '<div>Please&#38;nbsp;Sign&#38;nbsp;In</div>',
+    '<div>Please&#x26;nbsp;Sign&#x26;nbsp;In</div>'
   ];
 
   for (const sample of samples) {


### PR DESCRIPTION
## Summary
- decode numeric ampersand HTML references before running whitespace entity normalization in the Glasp sign-in detector
- extend the background self-check samples to cover decimal and hexadecimal encoded ampersands so the new behavior is exercised automatically

## Testing
- node - <<'NODE'
const fs = require('fs');
const vm = require('vm');

const chromeStub = {
  runtime: {
    onMessage: { addListener() {} },
    lastError: null
  },
  tabs: {
    create() {},
    onUpdated: { addListener() {} },
    onRemoved: { addListener() {} },
    get() {}
  },
  scripting: {
    executeScript() {
      return Promise.resolve([{ result: false }]);
    }
  }
};

const sandbox = {
  chrome: chromeStub,
  console,
  Map,
  setTimeout,
  clearTimeout,
  Promise,
  fetch: async () => { throw new Error('fetch not implemented in test sandbox'); }
};

const code = fs.readFileSync('background.js', 'utf8');
try {
  vm.runInNewContext(code, sandbox, { filename: 'background.js' });
  console.log('Self-check executed without sign-in detection warnings.');
} catch (error) {
  console.error('Execution failed:', error);
  process.exitCode = 1;
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68cf779511748320a814458007c4491c