### PR TITLE
Support JSON prompt flow with settings and updated background

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,594 +1,807 @@
-const pendingPrompts = new Map();
-const MAX_INJECTION_ATTEMPTS = 10;
+const GLASP_READER_BASE_URL = 'https://glasp.co/reader?url=';
+const GLASP_READER_LOAD_TIMEOUT_MS = 20000;
+const PENDING_STORAGE_KEY = 'pendingPromptsV2';
+const MAX_INJECTION_ATTEMPTS = 12;
 const RETRY_DELAY_MS = 1000;
 
-const GLASP_READER_BASE_URL = 'https://glasp.co/reader?url=';
-const GLASP_TEXT_KEYS = [
-  'text',
-  'textOriginal',
-  'textDisplay',
-  'caption',
-  'content',
-  'body',
-  'snippet',
-  'description',
-  'transcriptText',
-  'textContent',
-  'value',
-  'displayText',
-  'plainText'
-];
-const GLASP_TIMESTAMP_KEYS = [
-  'start',
-  'startMs',
-  'startTime',
-  'startTimeText',
-  'startSeconds',
-  'offset',
-  'offsetMs',
-  'offsetSeconds',
-  'startOffset',
-  'time',
-  'timecode',
-  'timeCode',
-  'ts',
-  'timestamp',
-  'displayTime',
-  'timeText',
-  'begin'
-];
+const activeInjections = new Set();
+let pendingPrompts = new Map();
+let pendingLoaded = false;
+let pendingLoadingPromise = null;
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message?.type === 'fetchTranscriptFromGlasp' && typeof message.videoUrl === 'string') {
-    fetchTranscriptFromGlasp(message.videoUrl)
-      .then((transcript) => sendResponse({ status: 'success', transcript }))
-      .catch((error) => {
+    (async () => {
+      try {
+        const transcript = await fetchTranscriptFromGlasp(message.videoUrl);
+        sendResponse({ status: 'success', transcript });
+      } catch (error) {
         console.error('Failed to fetch transcript from Glasp:', error);
         sendResponse({
           status: 'error',
-          error: error?.message || 'Unable to retrieve transcript from Glasp.'
+          error: error instanceof Error ? error.message : 'Unable to retrieve transcript from Glasp.'
         });
-      });
+      }
+    })();
     return true;
   }
 
   if (message?.type === 'openChatGPT' && typeof message.prompt === 'string') {
-    chrome.tabs.create({ url: 'https://chat.openai.com/' }, (tab) => {
-      if (tab?.id !== undefined) {
-        pendingPrompts.set(tab.id, { prompt: message.prompt, attempts: 0 });
+    (async () => {
+      try {
+        const response = await openChatGPTTab(message.prompt, message.preferredHost);
+        sendResponse(response);
+      } catch (error) {
+        console.error('Failed to open ChatGPT tab:', error);
+        sendResponse({
+          status: 'error',
+          error: error instanceof Error ? error.message : 'Unable to open ChatGPT.'
+        });
       }
-    });
-    sendResponse({ status: 'opening' });
+    })();
     return true;
   }
+
   return false;
 });
 
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  const pending = pendingPrompts.get(tabId);
-  if (!pending) {
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  try {
+    await ensurePendingPromptsLoaded();
+  } catch (error) {
+    console.error('Unable to load pending prompts from storage.', error);
     return;
   }
 
-  const updatedUrl = changeInfo.url || tab.url;
-  if (!updatedUrl?.startsWith('https://chat.openai.com/')) {
+  if (!pendingPrompts.has(tabId)) {
+    return;
+  }
+
+  const updatedUrl = changeInfo.url || tab?.url || '';
+  if (!isChatUrl(updatedUrl)) {
     return;
   }
 
   if (changeInfo.status === 'complete' || changeInfo.url) {
-    attemptPromptInjection(tabId);
+    scheduleInjectionAttempt(tabId, 0);
   }
 });
 
-chrome.tabs.onRemoved.addListener((tabId) => {
-  pendingPrompts.delete(tabId);
+chrome.tabs.onRemoved.addListener(async (tabId) => {
+  activeInjections.delete(tabId);
+  try {
+    await removePendingPrompt(tabId);
+  } catch (error) {
+    console.error('Failed to clean up pending prompt for closed tab', tabId, error);
+  }
 });
 
-const attemptPromptInjection = (tabId) => {
-  const pending = pendingPrompts.get(tabId);
-  if (!pending) {
+(async () => {
+  try {
+    await ensurePendingPromptsLoaded();
+  } catch (error) {
+    console.error('Failed to load pending prompts during startup.', error);
     return;
   }
 
-  if (pending.attempts >= MAX_INJECTION_ATTEMPTS) {
-    console.warn('Max prompt injection attempts reached for tab', tabId);
-    pendingPrompts.delete(tabId);
-    return;
-  }
-
-  pending.attempts += 1;
-
-  chrome.scripting
-    .executeScript({
-      target: { tabId },
-      world: 'MAIN',
-      func: injectPrompt,
-      args: [pending.prompt]
-    })
-    .then((results) => {
-      const [result] = results || [];
-      if (result?.result) {
-        pendingPrompts.delete(tabId);
+  for (const tabId of pendingPrompts.keys()) {
+    try {
+      const tab = await chrome.tabs.get(tabId);
+      if (tab?.url && isChatUrl(tab.url)) {
+        scheduleInjectionAttempt(tabId, RETRY_DELAY_MS);
       } else {
-        scheduleRetry(tabId);
+        await removePendingPrompt(tabId);
       }
-    })
-    .catch((error) => {
-      console.error('Failed to inject prompt:', error);
-      pendingPrompts.delete(tabId);
-    });
-};
-
-const scheduleRetry = (tabId) => {
-  const pending = pendingPrompts.get(tabId);
-  if (!pending) {
-    return;
-  }
-
-  if (pending.attempts >= MAX_INJECTION_ATTEMPTS) {
-    console.warn('Retry limit reached before scheduling for tab', tabId);
-    pendingPrompts.delete(tabId);
-    return;
-  }
-
-  setTimeout(() => {
-    const currentPending = pendingPrompts.get(tabId);
-    if (!currentPending) {
-      return;
-    }
-
-    chrome.tabs.get(tabId, (tab) => {
-      if (chrome.runtime.lastError) {
-        pendingPrompts.delete(tabId);
-        return;
-      }
-
-      if (tab?.url?.startsWith('https://chat.openai.com/')) {
-        attemptPromptInjection(tabId);
-      }
-    });
-  }, RETRY_DELAY_MS);
-};
-
-function injectPrompt(prompt) {
-  const findTextArea = () => {
-    const selectors = [
-      'textarea#prompt-textarea',
-      'textarea[data-id="root"]',
-      'textarea[data-id="prompt-textarea"]',
-      'textarea[placeholder*="Send a message"]',
-      'form textarea'
-    ];
-
-    for (const selector of selectors) {
-      const element = document.querySelector(selector);
-      if (element) {
-        return element;
-      }
-    }
-
-    return null;
-  };
-
-  const textArea = findTextArea();
-  if (!textArea) {
-    console.warn('ChatGPT text area not found.');
-    return false;
-  }
-
-  textArea.focus();
-  textArea.value = prompt;
-  const inputEvent = new Event('input', { bubbles: true });
-  textArea.dispatchEvent(inputEvent);
-  return true;
-}
-
-async function fetchTranscriptFromGlasp(videoUrl) {
-  const targetUrl = `${GLASP_READER_BASE_URL}${encodeURIComponent(videoUrl)}`;
-  let response;
-  try {
-    response = await fetch(targetUrl, {
-      method: 'GET',
-      credentials: 'include',
-      headers: {
-        Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'
-      }
-    });
-  } catch (error) {
-    throw new Error('Unable to reach Glasp.');
-  }
-
-  if (!response.ok) {
-    throw new Error(`Glasp request failed with status ${response.status}`);
-  }
-
-  const html = await response.text();
-  return parseTranscriptFromGlaspHtml(html);
-}
-
-function parseTranscriptFromGlaspHtml(html) {
-  if (typeof html !== 'string' || html.length === 0) {
-    throw new Error('Empty response received from Glasp.');
-  }
-
-  if (/Attention Required! \| Cloudflare/i.test(html)) {
-    throw new Error('Glasp is requesting additional verification. Open glasp.co in your browser and retry.');
-  }
-
-  const signInMatch = detectGlaspSignInPrompt(html);
-
-  const nextDataMatch = html.match(/<script[^>]+id="__NEXT_DATA__"[^>]*>([\s\S]*?)<\/script>/);
-  if (!nextDataMatch) {
-    if (signInMatch) {
-      throw new Error('Please sign in to Glasp in this browser to access transcripts.');
-    }
-    throw new Error('Unable to locate transcript data on Glasp.');
-  }
-
-  let nextData;
-  try {
-    nextData = JSON.parse(nextDataMatch[1]);
-  } catch (error) {
-    throw new Error('Failed to parse transcript data returned by Glasp.');
-  }
-
-  const segments = extractTranscriptSegments(nextData);
-  if (!segments || segments.length === 0) {
-    if (signInMatch) {
-      throw new Error('Please sign in to Glasp to view transcripts for this video.');
-    }
-    throw new Error('Transcript data not available from Glasp for this video.');
-  }
-
-  return segments
-    .map((segment) => {
-      const text = segment.text;
-      if (segment.timestamp) {
-        return `[${segment.timestamp}] ${text}`;
-      }
-      return text;
-    })
-    .join('\n');
-}
-
-function detectGlaspSignInPrompt(html) {
-  if (typeof html !== 'string' || html.length === 0) {
-    return false;
-  }
-
-  const signInPattern = /Please\s+Sign\s+In/i;
-
-  try {
-    if (typeof DOMParser === 'function') {
-      const parser = new DOMParser();
-      const doc = parser.parseFromString(html, 'text/html');
-      const bodyText = doc?.body?.textContent || '';
-      if (bodyText && signInPattern.test(bodyText)) {
-        return true;
-      }
-    }
-  } catch (error) {
-    // Ignore DOM parsing errors and fall back to text extraction via regex replacements.
-  }
-
-  const textOnly = html
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ');
-
-  const normalizedText = decodeHtmlEntities(textOnly);
-
-  return signInPattern.test(normalizedText);
-}
-
-function decodeHtmlEntities(text) {
-  if (typeof text !== 'string' || text.length === 0) {
-    return '';
-  }
-
-  let decoded = text;
-
-  decoded = decoded.replace(/&#(\d+);/gi, (match, value) => {
-    const codePoint = Number.parseInt(value, 10);
-    return codePoint === 38 ? '&' : match;
-  });
-  decoded = decoded.replace(/&#x([0-9a-f]+);/gi, (match, value) => {
-    const codePoint = Number.parseInt(value, 16);
-    return codePoint === 0x26 ? '&' : match;
-  });
-  decoded = decoded.replace(/&amp;/gi, '&');
-  decoded = decoded.replace(/&lt;/gi, '<');
-  decoded = decoded.replace(/&gt;/gi, '>');
-
-  const whitespaceEntityPatterns = [
-    /&nbsp;/gi,
-    /&#160;/gi,
-    /&#xA0;/gi,
-    /&#xa0;/gi,
-    /&NonBreakingSpace;/gi,
-    /&ensp;/gi,
-    /&#8194;/gi,
-    /&#x2002;/gi,
-    /&emsp;/gi,
-    /&#8195;/gi,
-    /&#x2003;/gi,
-    /&thinsp;/gi,
-    /&#8201;/gi,
-    /&#x2009;/gi
-  ];
-
-  for (const pattern of whitespaceEntityPatterns) {
-    decoded = decoded.replace(pattern, ' ');
-  }
-
-  return decoded;
-}
-
-(() => {
-  const samples = [
-    '<div>Please&nbsp;Sign&nbsp;In</div>',
-    '<div>Please&amp;nbsp;Sign&amp;nbsp;In</div>',
-    '<div>Please&#38;nbsp;Sign&#38;nbsp;In</div>',
-    '<div>Please&#x26;nbsp;Sign&#x26;nbsp;In</div>',
-    '<div>Please&#x26;amp;nbsp;Sign</div>',
-    '<div>Please&#38;amp;nbsp;Sign</div>'
-  ];
-
-  for (const sample of samples) {
-    if (!detectGlaspSignInPrompt(sample)) {
-      console.warn('Sign-in detection failed for HTML entity sample:', sample);
-      break;
+    } catch (error) {
+      await removePendingPrompt(tabId);
     }
   }
 })();
 
-function extractTranscriptSegments(root) {
-  const visited = new WeakSet();
-  let best = null;
+async function fetchTranscriptFromGlasp(videoUrl) {
+  const targetUrl = `${GLASP_READER_BASE_URL}${encodeURIComponent(videoUrl)}`;
+  const readerTab = await chrome.tabs.create({ url: targetUrl, active: false });
+  if (!readerTab?.id) {
+    throw new Error('Unable to open Glasp reader.');
+  }
 
-  const visit = (node) => {
-    if (!node || typeof node !== 'object') {
+  let tabClosed = false;
+  const tabId = readerTab.id;
+
+  const cleanup = async () => {
+    if (tabClosed) {
       return;
     }
-
-    if (visited.has(node)) {
-      return;
-    }
-    visited.add(node);
-
-    if (Array.isArray(node)) {
-      const segments = node.map((item) => normalizeTranscriptSegment(item)).filter(Boolean);
-      if (segments.length >= 5) {
-        const timestampCount = segments.filter((segment) => Boolean(segment.timestamp)).length;
-        const averageLength =
-          segments.reduce((total, segment) => total + segment.text.length, 0) / segments.length;
-
-        const meetsTimestampRequirement = timestampCount >= Math.max(3, Math.floor(segments.length * 0.5));
-        const meetsLengthRequirement = averageLength >= 8;
-
-        if ((meetsTimestampRequirement && meetsLengthRequirement) || (!best && segments.length >= 5)) {
-          if (!best || segments.length > best.length) {
-            best = segments;
-          }
-        }
+    tabClosed = true;
+    try {
+      await chrome.tabs.remove(tabId);
+    } catch (error) {
+      if (error && typeof error.message === 'string' && /No tab with id/.test(error.message)) {
+        return;
       }
-
-      for (const item of node) {
-        if (item && typeof item === 'object') {
-          visit(item);
-        }
-      }
-      return;
-    }
-
-    for (const value of Object.values(node)) {
-      if (value && typeof value === 'object') {
-        visit(value);
-      }
+      console.debug('Failed to close Glasp reader tab', error);
     }
   };
 
-  visit(root);
-  return best;
+  try {
+    await waitForTabComplete(tabId, GLASP_READER_LOAD_TIMEOUT_MS);
+    const pageText = await getTabInnerText(tabId);
+    const transcript = parseTranscriptFromReaderText(pageText);
+    await cleanup();
+    return transcript;
+  } catch (error) {
+    await cleanup();
+    throw error instanceof Error ? error : new Error('Unable to read transcript from Glasp.');
+  }
 }
 
-function normalizeTranscriptSegment(item) {
-  if (!item || typeof item !== 'object') {
-    return null;
+async function openChatGPTTab(prompt, preferredHost) {
+  if (typeof prompt !== 'string' || !prompt.trim()) {
+    throw new Error('Invalid prompt supplied.');
   }
 
-  const text = extractTextValue(item);
-  if (!text) {
-    return null;
+  const host = normalizeChatHost(preferredHost);
+  const url = `https://${host}/`;
+  const tab = await chrome.tabs.create({ url, active: true });
+
+  if (!tab?.id) {
+    throw new Error('Failed to open ChatGPT tab.');
   }
 
-  const timestamp = extractTimestampValue(item);
-  return { text, timestamp };
+  await setPendingPrompt(tab.id, { prompt, attempts: 0, host });
+  scheduleInjectionAttempt(tab.id, 1500);
+  return { status: 'opening', tabId: tab.id };
 }
 
-function extractTextValue(node) {
-  const visited = new WeakSet();
-  const stack = [node];
-
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (current == null) {
-      continue;
-    }
-
-    if (typeof current === 'string') {
-      const cleaned = cleanText(current);
-      if (cleaned) {
-        return cleaned;
-      }
-      continue;
-    }
-
-    if (Array.isArray(current)) {
-      for (let index = current.length - 1; index >= 0; index -= 1) {
-        stack.push(current[index]);
-      }
-      continue;
-    }
-
-    if (typeof current === 'object') {
-      if (visited.has(current)) {
-        continue;
-      }
-      visited.add(current);
-
-      if (typeof current.simpleText === 'string') {
-        const simple = cleanText(current.simpleText);
-        if (simple) {
-          return simple;
-        }
-      }
-
-      if (typeof current.text === 'string') {
-        const text = cleanText(current.text);
-        if (text) {
-          return text;
-        }
-      }
-
-      for (const key of GLASP_TEXT_KEYS) {
-        if (key in current) {
-          stack.push(current[key]);
-        }
-      }
-
-      for (const value of Object.values(current)) {
-        if (value && (typeof value === 'object' || typeof value === 'string')) {
-          stack.push(value);
-        }
-      }
-    }
+function scheduleInjectionAttempt(tabId, delay) {
+  if (activeInjections.has(tabId)) {
+    return;
   }
 
-  return null;
+  setTimeout(() => {
+    void attemptPromptInjection(tabId);
+  }, Math.max(0, delay));
 }
 
-function extractTimestampValue(node) {
-  const visited = new WeakSet();
-  const stack = [node];
+async function attemptPromptInjection(tabId) {
+  if (activeInjections.has(tabId)) {
+    return;
+  }
+  activeInjections.add(tabId);
 
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (current == null) {
+  try {
+    await ensurePendingPromptsLoaded();
+    const pending = pendingPrompts.get(tabId);
+    if (!pending) {
+      return;
+    }
+
+    if ((pending.attempts ?? 0) >= MAX_INJECTION_ATTEMPTS) {
+      console.warn('Maximum prompt injection attempts reached for tab', tabId);
+      await removePendingPrompt(tabId);
+      return;
+    }
+
+    pending.attempts = (pending.attempts ?? 0) + 1;
+    await persistPendingPrompts();
+
+    const [{ result }] = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: 'MAIN',
+      func: injectPromptAndSend,
+      args: [pending.prompt]
+    });
+
+    const status = result?.status || (result === true ? 'success' : 'retry');
+
+    if (status === 'success') {
+      await removePendingPrompt(tabId);
+      return;
+    }
+
+    if (status === 'permanent-failure') {
+      console.warn('Prompt injection reported a permanent failure for tab', tabId, result?.reason);
+      await removePendingPrompt(tabId);
+      return;
+    }
+
+    if ((pending.attempts ?? 0) < MAX_INJECTION_ATTEMPTS) {
+      scheduleInjectionAttempt(tabId, RETRY_DELAY_MS);
+    } else {
+      await removePendingPrompt(tabId);
+    }
+  } catch (error) {
+    console.error('Prompt injection failed for tab', tabId, error);
+    await removePendingPrompt(tabId);
+  } finally {
+    activeInjections.delete(tabId);
+  }
+}
+
+async function waitForTabComplete(tabId, timeoutMs) {
+  const startTime = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      chrome.tabs.onUpdated.removeListener(listener);
+      reject(new Error('Timed out while waiting for Glasp to load.'));
+    }, timeoutMs);
+
+    const listener = (updatedTabId, changeInfo) => {
+      if (updatedTabId !== tabId) {
+        return;
+      }
+
+      if (changeInfo.status === 'complete') {
+        clearTimeout(timeoutId);
+        chrome.tabs.onUpdated.removeListener(listener);
+        resolve();
+      }
+
+      if (changeInfo.status === 'loading' && Date.now() - startTime > timeoutMs) {
+        clearTimeout(timeoutId);
+        chrome.tabs.onUpdated.removeListener(listener);
+        reject(new Error('Glasp took too long to load.'));
+      }
+    };
+
+    chrome.tabs.onUpdated.addListener(listener);
+  });
+}
+
+async function getTabInnerText(tabId) {
+  try {
+    const [{ result }] = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: 'MAIN',
+      func: () => document?.body?.innerText || ''
+    });
+    if (typeof result !== 'string') {
+      throw new Error('Unable to read transcript content from Glasp.');
+    }
+    return result;
+  } catch (error) {
+    throw error instanceof Error ? error : new Error('Failed to read transcript from Glasp.');
+  }
+}
+
+function parseTranscriptFromReaderText(pageText) {
+  if (typeof pageText !== 'string' || pageText.trim().length === 0) {
+    throw new Error('Empty response received from Glasp.');
+  }
+
+  if (/Attention Required! \| Cloudflare/i.test(pageText)) {
+    throw new Error('Glasp is requesting additional verification. Open glasp.co in your browser and retry.');
+  }
+
+  if (/Please\s+(?:sign\s+in|log\s+in)/i.test(pageText)) {
+    throw new Error('Please sign in to Glasp in this browser to access transcripts.');
+  }
+
+  const lines = pageText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const transcriptStart = lines.findIndex((line) => /^Transcript$/i.test(line) || /Transcript:?$/i.test(line));
+  const contentLines = transcriptStart >= 0 ? lines.slice(transcriptStart + 1) : lines;
+
+  const stopPattern = /^(Summary|Highlights|Notes?|Comments|Write a comment|Related)/i;
+  const timestampInline = /^(?:\[\s*)?((?:\d{1,2}:)?\d{1,2}:\d{2})(?:\s*\]?)(?:\s*[-–:\u2013]\s*|\s+)(.+)$/;
+  const timestampSolo = /^(?:\[\s*)?((?:\d{1,2}:)?\d{1,2}:\d{2})(?:\s*\]?)(?:\s*[-–:\u2013]\s*)?$/;
+
+  const segments = [];
+  let index = 0;
+
+  while (index < contentLines.length) {
+    const line = contentLines[index];
+    if (stopPattern.test(line)) {
+      break;
+    }
+
+    const inlineMatch = line.match(timestampInline);
+    if (inlineMatch) {
+      const [, timestamp, text] = inlineMatch;
+      segments.push(formatTranscriptSegment(timestamp, text));
+      index += 1;
       continue;
     }
 
-    if (typeof current === 'number') {
-      const formatted = formatSecondsToTimestamp(current);
-      if (formatted) {
-        return formatted;
-      }
-      continue;
-    }
-
-    if (typeof current === 'string') {
-      const formatted = normalizeTimestampString(current);
-      if (formatted) {
-        return formatted;
-      }
-      continue;
-    }
-
-    if (Array.isArray(current)) {
-      for (let index = current.length - 1; index >= 0; index -= 1) {
-        stack.push(current[index]);
-      }
-      continue;
-    }
-
-    if (typeof current === 'object') {
-      if (visited.has(current)) {
-        continue;
-      }
-      visited.add(current);
-
-      for (const key of GLASP_TIMESTAMP_KEYS) {
-        if (key in current) {
-          stack.push(current[key]);
+    const soloMatch = line.match(timestampSolo);
+    if (soloMatch) {
+      const [, timestamp] = soloMatch;
+      index += 1;
+      const textParts = [];
+      while (index < contentLines.length) {
+        const nextLine = contentLines[index];
+        if (stopPattern.test(nextLine) || timestampSolo.test(nextLine) || timestampInline.test(nextLine)) {
+          break;
         }
+        textParts.push(nextLine);
+        index += 1;
       }
-
-      for (const value of Object.values(current)) {
-        if (value && (typeof value === 'object' || typeof value === 'string' || typeof value === 'number')) {
-          stack.push(value);
-        }
+      if (textParts.length > 0) {
+        segments.push(formatTranscriptSegment(timestamp, textParts.join(' ')));
       }
+      continue;
     }
+
+    index += 1;
   }
 
-  return null;
-}
-
-function cleanText(value) {
-  if (typeof value !== 'string') {
-    return null;
-  }
-  const cleaned = value.replace(/\s+/g, ' ').trim();
-  return cleaned || null;
-}
-
-function normalizeTimestampString(value) {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  const colonMatch = trimmed.match(/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/);
-  if (colonMatch) {
-    const [, part1, part2, part3] = colonMatch;
-    if (typeof part3 === 'string') {
-      const hours = part1.padStart(2, '0');
-      const minutes = part2.padStart(2, '0');
-      const seconds = part3.padStart(2, '0');
-      return `${hours}:${minutes}:${seconds}`;
+  if (segments.length === 0) {
+    const fallbackTranscript = contentLines.join('\n').trim();
+    if (!fallbackTranscript) {
+      throw new Error('Transcript data not found on Glasp for this video.');
     }
-    const minutes = part1.padStart(2, '0');
-    const seconds = part2.padStart(2, '0');
-    return `${minutes}:${seconds}`;
+    return fallbackTranscript;
   }
 
-  const numeric = Number(trimmed);
-  if (!Number.isNaN(numeric)) {
-    return formatSecondsToTimestamp(numeric);
-  }
-
-  return null;
+  return segments.join('\n');
 }
 
-function formatSecondsToTimestamp(value) {
-  if (!Number.isFinite(value)) {
-    return null;
+function formatTranscriptSegment(timestamp, text) {
+  const normalizedText = (text || '').replace(/\s+/g, ' ').trim();
+  const normalizedTimestamp = normalizeTimestamp(timestamp);
+  if (normalizedText) {
+    return `[${normalizedTimestamp}] ${normalizedText}`;
+  }
+  return `[${normalizedTimestamp}]`;
+}
+
+function normalizeTimestamp(raw) {
+  if (typeof raw !== 'string') {
+    return '00:00';
+  }
+  const cleaned = raw.replace(/[^0-9:]/g, '');
+  if (!cleaned) {
+    return '00:00';
   }
 
-  let seconds = value;
-  if (seconds > 1000 && seconds < 1000000) {
-    seconds = seconds / 1000;
+  const parts = cleaned.split(':').map((part) => Number.parseInt(part, 10)).filter((value) => !Number.isNaN(value));
+  if (parts.length === 0) {
+    return cleaned;
   }
 
-  if (seconds < 0) {
-    seconds = 0;
+  let totalSeconds = 0;
+  for (const part of parts) {
+    totalSeconds = totalSeconds * 60 + part;
   }
 
-  const rounded = Math.max(0, Math.round(seconds));
-  const hours = Math.floor(rounded / 3600);
-  const minutes = Math.floor((rounded % 3600) / 60);
-  const secs = rounded % 60;
+  if (!Number.isFinite(totalSeconds)) {
+    return cleaned;
+  }
 
-  const paddedMinutes = String(minutes).padStart(2, '0');
-  const paddedSeconds = String(secs).padStart(2, '0');
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const mm = String(minutes).padStart(2, '0');
+  const ss = String(seconds).padStart(2, '0');
 
   if (hours > 0) {
-    return `${String(hours).padStart(2, '0')}:${paddedMinutes}:${paddedSeconds}`;
+    return `${String(hours).padStart(2, '0')}:${mm}:${ss}`;
+  }
+  return `${mm}:${ss}`;
+}
+
+function isChatUrl(url) {
+  if (typeof url !== 'string') {
+    return false;
+  }
+  return url.startsWith('https://chat.openai.com') || url.startsWith('https://chatgpt.com');
+}
+
+function normalizeChatHost(host) {
+  if (typeof host === 'string') {
+    const trimmed = host.trim().toLowerCase();
+    if (trimmed === 'chat.openai.com' || trimmed === 'chat.openai.com/') {
+      return 'chat.openai.com';
+    }
+    if (trimmed === 'chatgpt.com' || trimmed === 'chatgpt.com/') {
+      return 'chatgpt.com';
+    }
+  }
+  return 'chatgpt.com';
+}
+
+async function ensurePendingPromptsLoaded() {
+  if (pendingLoaded) {
+    return;
+  }
+  if (pendingLoadingPromise) {
+    await pendingLoadingPromise;
+    return;
   }
 
-  return `${paddedMinutes}:${paddedSeconds}`;
+  pendingLoadingPromise = (async () => {
+    try {
+      const stored = await chrome.storage.session.get(PENDING_STORAGE_KEY);
+      const rawEntries = stored?.[PENDING_STORAGE_KEY];
+      if (rawEntries && typeof rawEntries === 'object') {
+        const restored = new Map();
+        for (const [key, value] of Object.entries(rawEntries)) {
+          const numericKey = Number.parseInt(key, 10);
+          if (Number.isNaN(numericKey)) {
+            continue;
+          }
+          if (value && typeof value.prompt === 'string') {
+            restored.set(numericKey, {
+              prompt: value.prompt,
+              attempts: Number.isFinite(value.attempts) ? value.attempts : 0,
+              host: typeof value.host === 'string' ? value.host : undefined
+            });
+          }
+        }
+        pendingPrompts = restored;
+      } else {
+        pendingPrompts = new Map();
+      }
+    } finally {
+      pendingLoaded = true;
+      pendingLoadingPromise = null;
+    }
+  })();
+
+  await pendingLoadingPromise;
+}
+
+async function persistPendingPrompts() {
+  await ensurePendingPromptsLoaded();
+  if (pendingPrompts.size === 0) {
+    await chrome.storage.session.remove(PENDING_STORAGE_KEY);
+    return;
+  }
+
+  const serialized = {};
+  for (const [tabId, value] of pendingPrompts.entries()) {
+    serialized[String(tabId)] = {
+      prompt: value.prompt,
+      attempts: value.attempts ?? 0,
+      host: value.host
+    };
+  }
+
+  await chrome.storage.session.set({ [PENDING_STORAGE_KEY]: serialized });
+}
+
+async function setPendingPrompt(tabId, data) {
+  await ensurePendingPromptsLoaded();
+  pendingPrompts.set(tabId, { ...data, attempts: data.attempts ?? 0 });
+  await persistPendingPrompts();
+}
+
+async function removePendingPrompt(tabId) {
+  await ensurePendingPromptsLoaded();
+  if (!pendingPrompts.has(tabId)) {
+    return;
+  }
+  pendingPrompts.delete(tabId);
+  await persistPendingPrompts();
+}
+
+function injectPromptAndSend(prompt) {
+  if (typeof prompt !== 'string' || !prompt.trim()) {
+    return { status: 'permanent-failure', reason: 'Invalid prompt provided.' };
+  }
+
+  const preferredSelectors = [
+    'textarea#prompt-textarea',
+    'textarea[data-id="root"]',
+    'textarea[data-id="prompt-textarea"]',
+    'textarea[placeholder*="Send a message"]',
+    '[contenteditable="true"]',
+    '[role="textbox"]'
+  ];
+
+  const composer = findEditor(preferredSelectors);
+  if (!composer) {
+    return { status: 'retry', reason: 'Composer not found yet.' };
+  }
+
+  if (!applyPromptToComposer(composer, prompt)) {
+    return { status: 'permanent-failure', reason: 'Unable to write prompt into composer.' };
+  }
+
+  if (!sendMessage(composer)) {
+    return { status: 'retry', reason: 'Send button not ready.' };
+  }
+
+  return { status: 'success' };
+
+  function findEditor(selectors) {
+    for (const selector of selectors) {
+      const element = deepQuerySelector(selector);
+      if (element && isEditable(element)) {
+        return element;
+      }
+    }
+
+    const matches = [];
+    traverse(document, (node) => {
+      if (node instanceof HTMLElement && isEditable(node)) {
+        matches.push(node);
+      }
+    });
+
+    if (matches.length === 0) {
+      return null;
+    }
+
+    matches.sort((a, b) => getElementScore(b) - getElementScore(a));
+    return matches[0];
+  }
+
+  function deepQuerySelector(selector) {
+    const queue = [document.documentElement];
+    const visited = new Set();
+
+    while (queue.length > 0) {
+      const node = queue.shift();
+      if (!node || visited.has(node)) {
+        continue;
+      }
+      visited.add(node);
+
+      if (node instanceof Element) {
+        const found = node.querySelector(selector);
+        if (found) {
+          return found;
+        }
+
+        if (node.shadowRoot) {
+          queue.push(node.shadowRoot);
+        }
+      }
+
+      if (node instanceof ShadowRoot || node instanceof DocumentFragment) {
+        queue.push(...node.children);
+      }
+    }
+
+    return null;
+  }
+
+  function traverse(root, visitor) {
+    const stack = [root];
+    const seen = new Set();
+
+    while (stack.length > 0) {
+      const node = stack.pop();
+      if (!node || seen.has(node)) {
+        continue;
+      }
+      seen.add(node);
+      visitor(node);
+
+      if (node instanceof Element) {
+        if (node.shadowRoot) {
+          stack.push(node.shadowRoot);
+        }
+        for (let i = node.children.length - 1; i >= 0; i -= 1) {
+          stack.push(node.children[i]);
+        }
+      } else if (node instanceof ShadowRoot || node instanceof DocumentFragment) {
+        for (let i = node.children.length - 1; i >= 0; i -= 1) {
+          stack.push(node.children[i]);
+        }
+      }
+    }
+  }
+
+  function isEditable(element) {
+    if (!(element instanceof HTMLElement)) {
+      return false;
+    }
+
+    if (element.tagName === 'TEXTAREA') {
+      return isVisible(element);
+    }
+
+    if (element.isContentEditable) {
+      return isVisible(element);
+    }
+
+    const role = element.getAttribute('role');
+    if (role && role.toLowerCase() === 'textbox') {
+      return isVisible(element);
+    }
+
+    return false;
+  }
+
+  function isVisible(element) {
+    const rect = element.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) {
+      return false;
+    }
+    const style = window.getComputedStyle(element);
+    return style.visibility !== 'hidden' && style.display !== 'none';
+  }
+
+  function getElementScore(element) {
+    const rect = element.getBoundingClientRect();
+    return rect.width * rect.height;
+  }
+
+  function applyPromptToComposer(element, value) {
+    try {
+      element.focus({ preventScroll: false });
+    } catch (error) {
+      element.focus();
+    }
+
+    if ('value' in element) {
+      setNativeValue(element, value);
+      dispatchInputEvents(element, value);
+      element.scrollTop = element.scrollHeight;
+      return true;
+    }
+
+    if (element.isContentEditable || element.getAttribute('contenteditable') === 'true' || element.getAttribute('role') === 'textbox') {
+      clearEditableContent(element);
+      const success = document.execCommand('insertText', false, value);
+      if (!success || element.innerText.trim() !== value.trim()) {
+        element.innerText = value;
+      }
+      dispatchInputEvents(element, value);
+      return true;
+    }
+
+    return false;
+  }
+
+  function clearEditableContent(element) {
+    const selection = window.getSelection();
+    if (!selection) {
+      element.innerHTML = '';
+      return;
+    }
+
+    selection.removeAllRanges();
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    selection.addRange(range);
+    selection.deleteFromDocument();
+  }
+
+  function setNativeValue(element, value) {
+    const { set: valueSetter } = Object.getOwnPropertyDescriptor(element, 'value') || {};
+    const prototype =
+      element instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : element instanceof HTMLInputElement
+          ? HTMLInputElement.prototype
+          : HTMLElement.prototype;
+    const { set: prototypeSetter } = Object.getOwnPropertyDescriptor(prototype, 'value') || {};
+
+    if (prototypeSetter && valueSetter !== prototypeSetter) {
+      prototypeSetter.call(element, value);
+    } else if (valueSetter) {
+      valueSetter.call(element, value);
+    } else {
+      element.value = value;
+    }
+  }
+
+  function dispatchInputEvents(element, value) {
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    try {
+      element.dispatchEvent(
+        new InputEvent('input', {
+          bubbles: true,
+          data: value,
+          inputType: 'insertText'
+        })
+      );
+    } catch (error) {
+      // Ignore environments where InputEvent is not supported.
+    }
+  }
+
+  function sendMessage(element) {
+    const sendButton = findSendButton(element);
+    if (sendButton) {
+      sendButton.click();
+      return true;
+    }
+
+    try {
+      element.focus();
+      const keyDown = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        which: 13,
+        bubbles: true
+      });
+      element.dispatchEvent(keyDown);
+
+      const keyUp = new KeyboardEvent('keyup', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        which: 13,
+        bubbles: true
+      });
+      element.dispatchEvent(keyUp);
+      return true;
+    } catch (error) {
+      console.warn('Failed to simulate Enter key press', error);
+      return false;
+    }
+  }
+
+  function findSendButton(contextElement) {
+    const candidates = [];
+    traverse(document, (node) => {
+      if (!(node instanceof HTMLElement)) {
+        return;
+      }
+
+      if (!isPotentialSendButton(node)) {
+        return;
+      }
+
+      const rect = node.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) {
+        return;
+      }
+
+      candidates.push({ node, distance: distanceTo(contextElement, node) });
+    });
+
+    if (candidates.length === 0) {
+      return null;
+    }
+
+    candidates.sort((a, b) => a.distance - b.distance);
+    return candidates[0].node;
+  }
+
+  function isPotentialSendButton(element) {
+    if (!(element instanceof HTMLElement)) {
+      return false;
+    }
+
+    const role = element.getAttribute('role');
+    if (element.tagName !== 'BUTTON' && role !== 'button') {
+      return false;
+    }
+
+    const labelSources = [
+      element.getAttribute('aria-label'),
+      element.getAttribute('title'),
+      element.dataset?.testid,
+      element.textContent
+    ];
+
+    const normalizedLabel = labelSources
+      .filter(Boolean)
+      .map((value) => value.trim().toLowerCase())
+      .find((value) => value.includes('send') || value.includes('submit') || value.includes('enter'));
+
+    if (normalizedLabel) {
+      return true;
+    }
+
+    const datasetTestId = element.dataset?.testid || element.getAttribute('data-testid');
+    if (datasetTestId && datasetTestId.toLowerCase().includes('send')) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function distanceTo(from, to) {
+    try {
+      const rectA = from.getBoundingClientRect();
+      const rectB = to.getBoundingClientRect();
+      const dx = rectB.left - rectA.left;
+      const dy = rectB.top - rectA.top;
+      return Math.sqrt(dx * dx + dy * dy);
+    } catch (error) {
+      return Number.MAX_SAFE_INTEGER;
+    }
+  }
 }

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,115 +1,345 @@
-const BUTTON_ID = 'ytlm-summarize-btn';
-const BUTTON_LABEL_DEFAULT = 'Summarize with ChatGPT';
-const BUTTON_LABEL_LOADING = 'Fetching transcript…';
-const BUTTON_LABEL_OPENING = 'Opening ChatGPT…';
+const WATCH_BUTTON_ID = 'ytlm-summarize-btn';
+const WATCH_SETTINGS_BUTTON_ID = 'ytlm-settings-btn';
+const SHORTS_CONTAINER_ID = 'ytlm-floating-controls';
+const SHORTS_BUTTON_ID = 'ytlm-shorts-summarize-btn';
+const SHORTS_SETTINGS_BUTTON_ID = 'ytlm-floating-settings-btn';
+const SETTINGS_PANEL_ID = 'ytlm-settings-panel';
+const SETTINGS_STORAGE_KEY = 'ytlmSettingsV1';
+const STYLE_ELEMENT_ID = 'ytlm-shared-styles';
 
-const addButtonIfNeeded = () => {
-  if (document.getElementById(BUTTON_ID)) {
-    return;
-  }
-
-  const container = document.querySelector('#top-row #actions #top-level-buttons-computed');
-  const fallbackContainer = document.querySelector('#top-level-buttons-computed');
-  const targetContainer = container || fallbackContainer;
-
-  if (!targetContainer) {
-    return;
-  }
-
-  const button = document.createElement('button');
-  button.id = BUTTON_ID;
-  button.type = 'button';
-  button.textContent = BUTTON_LABEL_DEFAULT;
-
-  const referenceButton =
-    targetContainer.querySelector('button.yt-spec-button-shape-next') || targetContainer.querySelector('button');
-  if (referenceButton) {
-    button.className = referenceButton.className;
-  } else {
-    button.className = 'yt-spec-button-shape-next yt-spec-button-shape-next--outline yt-spec-button-shape-next--size-m';
-  }
-
-  button.setAttribute('aria-label', BUTTON_LABEL_DEFAULT);
-  button.style.marginLeft = '8px';
-  button.addEventListener('click', onButtonClick);
-  targetContainer.appendChild(button);
+const BUTTON_LABELS = {
+  idle: 'Summarize with ChatGPT',
+  loadingTranscript: 'Fetching transcript…',
+  openingChat: 'Opening ChatGPT…'
 };
 
-const onButtonClick = async () => {
-  const button = document.getElementById(BUTTON_ID);
-  if (!button) {
+const DEFAULT_SETTINGS = {
+  preferredChatHost: 'chatgpt.com',
+  overviewSentences: 3,
+  includeTakeaways: true,
+  includeActionSteps: true,
+  responseLanguage: 'English',
+  customInstructions: ''
+};
+
+let currentSettings = { ...DEFAULT_SETTINGS };
+let settingsLoaded = false;
+let settingsLoadPromise = null;
+let settingsPanelRefs = null;
+let lastFocusedElement = null;
+
+ensureGlobalStyles();
+ensureSettingsLoaded().catch((error) => console.error('Failed to pre-load settings', error));
+addOrUpdateButtons();
+
+const observer = new MutationObserver(() => {
+  addOrUpdateButtons();
+});
+
+if (document.body) {
+  observer.observe(document.body, { childList: true, subtree: true });
+} else {
+  document.addEventListener('DOMContentLoaded', () => {
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+}
+
+window.addEventListener('yt-navigate-finish', () => {
+  setTimeout(() => {
+    addOrUpdateButtons();
+    resetButtonStates();
+  }, 600);
+});
+
+function addOrUpdateButtons() {
+  ensureWatchButtons();
+  ensureShortsButtons();
+}
+
+function ensureWatchButtons() {
+  const container =
+    document.querySelector('#top-row #actions #top-level-buttons-computed') ||
+    document.querySelector('#top-level-buttons-computed');
+
+  if (!container) {
     return;
   }
 
-  button.disabled = true;
-  button.textContent = BUTTON_LABEL_LOADING;
+  let summarizeButton = document.getElementById(WATCH_BUTTON_ID);
+  if (!summarizeButton) {
+    summarizeButton = document.createElement('button');
+    summarizeButton.id = WATCH_BUTTON_ID;
+    summarizeButton.type = 'button';
+    summarizeButton.textContent = BUTTON_LABELS.idle;
+    summarizeButton.setAttribute('aria-label', BUTTON_LABELS.idle);
 
-  const canonicalUrl = getCanonicalVideoUrl();
-  const targetUrl = canonicalUrl || window.location.href;
+    const referenceButton =
+      container.querySelector('button.yt-spec-button-shape-next') || container.querySelector('button');
 
-  try {
-    const transcript = await fetchTranscript(targetUrl);
-    if (!transcript) {
-      alert('Transcript unavailable for this video.');
-      button.textContent = BUTTON_LABEL_DEFAULT;
-      button.disabled = false;
-      return;
+    if (referenceButton && referenceButton.className) {
+      summarizeButton.className = referenceButton.className;
+    } else {
+      summarizeButton.className =
+        'yt-spec-button-shape-next yt-spec-button-shape-next--outline yt-spec-button-shape-next--size-m';
     }
 
-    const titleElement = document.querySelector('h1.ytd-watch-metadata') || document.querySelector('h1.title');
-    const title = titleElement ? titleElement.innerText.trim() : document.title;
+    summarizeButton.style.marginLeft = '8px';
+    summarizeButton.addEventListener('click', () => handleSummarize(summarizeButton));
+    container.appendChild(summarizeButton);
+  }
+
+  setButtonState(summarizeButton, summarizeButton.dataset.ytlmState || 'idle');
+
+  let settingsButton = document.getElementById(WATCH_SETTINGS_BUTTON_ID);
+  if (!settingsButton) {
+    settingsButton = document.createElement('button');
+    settingsButton.id = WATCH_SETTINGS_BUTTON_ID;
+    settingsButton.type = 'button';
+    settingsButton.textContent = 'Settings';
+    settingsButton.setAttribute('aria-label', 'Open extension settings');
+
+    if (summarizeButton && summarizeButton.className) {
+      settingsButton.className = summarizeButton.className;
+    } else {
+      settingsButton.className = 'ytlm-secondary-action';
+    }
+
+    settingsButton.style.marginLeft = '8px';
+    settingsButton.addEventListener('click', openSettingsPanel);
+    container.appendChild(settingsButton);
+  }
+}
+
+function ensureShortsButtons() {
+  const isShorts = isShortsPage();
+  let container = document.getElementById(SHORTS_CONTAINER_ID);
+
+  if (!isShorts) {
+    if (container) {
+      container.remove();
+    }
+    return;
+  }
+
+  if (!container) {
+    if (!document.body) {
+      return;
+    }
+    container = document.createElement('div');
+    container.id = SHORTS_CONTAINER_ID;
+    document.body.appendChild(container);
+  }
+
+  let summarizeButton = document.getElementById(SHORTS_BUTTON_ID);
+  if (!summarizeButton) {
+    summarizeButton = document.createElement('button');
+    summarizeButton.id = SHORTS_BUTTON_ID;
+    summarizeButton.type = 'button';
+    summarizeButton.className = 'ytlm-floating-button';
+    summarizeButton.textContent = BUTTON_LABELS.idle;
+    summarizeButton.setAttribute('aria-label', BUTTON_LABELS.idle);
+    summarizeButton.addEventListener('click', () => handleSummarize(summarizeButton));
+    container.appendChild(summarizeButton);
+  }
+
+  setButtonState(summarizeButton, summarizeButton.dataset.ytlmState || 'idle');
+
+  let settingsButton = document.getElementById(SHORTS_SETTINGS_BUTTON_ID);
+  if (!settingsButton) {
+    settingsButton = document.createElement('button');
+    settingsButton.id = SHORTS_SETTINGS_BUTTON_ID;
+    settingsButton.type = 'button';
+    settingsButton.className = 'ytlm-floating-button ytlm-settings-toggle';
+    settingsButton.textContent = 'Settings';
+    settingsButton.setAttribute('aria-label', 'Open extension settings');
+    settingsButton.addEventListener('click', openSettingsPanel);
+    container.appendChild(settingsButton);
+  }
+}
+
+async function handleSummarize(button) {
+  if (!button || button.dataset.ytlmBusy === 'true') {
+    return;
+  }
+
+  button.dataset.ytlmBusy = 'true';
+  setButtonState(button, 'loadingTranscript');
+
+  try {
+    const settings = await ensureSettingsLoaded();
+    const canonicalUrl = getCanonicalVideoUrl();
+    const targetUrl = canonicalUrl || window.location.href;
+
+    const transcript = await fetchTranscript(targetUrl);
+    if (!transcript) {
+      throw new Error('Transcript unavailable for this video.');
+    }
+
+    const title = getVideoTitle();
     const prompt = buildPrompt({
       title,
       url: targetUrl,
-      transcript
+      transcript,
+      settings
     });
 
-    if (!chrome?.runtime?.sendMessage) {
-      console.error('chrome.runtime.sendMessage is unavailable.');
-      alert('Unable to communicate with the extension background script.');
-      button.textContent = BUTTON_LABEL_DEFAULT;
-      button.disabled = false;
-      return;
-    }
-
-    button.textContent = BUTTON_LABEL_OPENING;
-    chrome.runtime.sendMessage({ type: 'openChatGPT', prompt }, () => {
-      if (chrome.runtime.lastError) {
-        console.error('Failed to open ChatGPT tab', chrome.runtime.lastError);
-        alert('Unable to open ChatGPT. Check extension permissions.');
-      }
-
-      button.textContent = BUTTON_LABEL_DEFAULT;
-      button.disabled = false;
-    });
+    setButtonState(button, 'openingChat');
+    await openChatGPT(prompt, settings.preferredChatHost);
   } catch (error) {
-    console.error('Failed to fetch transcript', error);
-    const message = error?.message || 'An error occurred while fetching the transcript.';
+    console.error('Summarization failed', error);
+    const message = error instanceof Error ? error.message : 'An unexpected error occurred.';
     alert(`${message} See the console for details.`);
-    button.textContent = BUTTON_LABEL_DEFAULT;
-    button.disabled = false;
+  } finally {
+    setButtonState(button, 'idle');
+    button.dataset.ytlmBusy = 'false';
   }
-};
+}
 
-const buildPrompt = ({ title, url, transcript }) => {
+function setButtonState(button, state) {
+  if (!button) {
+    return;
+  }
+  const label = BUTTON_LABELS[state] || BUTTON_LABELS.idle;
+  button.dataset.ytlmState = state;
+  if (state === 'idle') {
+    button.disabled = false;
+  } else {
+    button.disabled = true;
+  }
+  button.textContent = label;
+  button.setAttribute('aria-label', label);
+}
+
+function resetButtonStates() {
+  const watchButton = document.getElementById(WATCH_BUTTON_ID);
+  const shortsButton = document.getElementById(SHORTS_BUTTON_ID);
+  if (watchButton) {
+    watchButton.dataset.ytlmBusy = 'false';
+    setButtonState(watchButton, 'idle');
+  }
+  if (shortsButton) {
+    shortsButton.dataset.ytlmBusy = 'false';
+    setButtonState(shortsButton, 'idle');
+  }
+}
+
+function isShortsPage() {
+  return window.location.pathname.startsWith('/shorts/');
+}
+
+function getCanonicalVideoUrl() {
+  const videoId = getCurrentVideoId();
+  if (!videoId) {
+    return null;
+  }
+  return `https://www.youtube.com/watch?v=${videoId}`;
+}
+
+function getCurrentVideoId() {
+  const urlVideoId = new URLSearchParams(window.location.search).get('v');
+  if (urlVideoId) {
+    return urlVideoId;
+  }
+
+  const shortsMatch = window.location.pathname.match(/\/shorts\/([^/?]+)/);
+  if (shortsMatch && shortsMatch[1]) {
+    return shortsMatch[1];
+  }
+
+  const playerElement = document.querySelector('ytd-player, ytd-watch-flexy');
+  const player = playerElement?.player_ || playerElement;
+
+  if (player?.getVideoData) {
+    try {
+      const videoData = player.getVideoData();
+      return videoData?.video_id || videoData?.videoId || null;
+    } catch (error) {
+      console.debug('Unable to read video data from player', error);
+    }
+  }
+
+  return (
+    playerElement?.__data?.playerResponse?.videoDetails?.videoId ||
+    playerElement?.__data?.playerResponse?.videoDetails?.video_id ||
+    null
+  );
+}
+
+function getVideoTitle() {
+  const selectors = [
+    'h1.ytd-watch-metadata',
+    'h1.title',
+    '#title h1',
+    'ytd-watch-flexy #title h1',
+    'ytd-watch-flexy #title yt-formatted-string',
+    'yt-formatted-string.ytd-watch-metadata',
+    'ytd-reel-player-header-renderer #title yt-formatted-string',
+    'yt-formatted-string.ytd-reel-title-renderer',
+    '#overlay #title yt-formatted-string',
+    'h1'
+  ];
+
+  for (const selector of selectors) {
+    const element = document.querySelector(selector);
+    const text = element?.innerText || element?.textContent;
+    if (text) {
+      const normalized = text.trim();
+      if (normalized) {
+        return normalized;
+      }
+    }
+  }
+
+  return document.title;
+}
+
+function buildPrompt({ title, url, transcript, settings }) {
   const trimmedTranscript = transcript.trim();
-  return [
-    'You are an expert note taker. Please summarize the following YouTube video transcript.',
-    '',
-    `Title: ${title}`,
-    `URL: ${url}`,
-    '',
-    'Instructions:',
-    '1. Provide a concise overview in 2-3 sentences.',
-    '2. List the main takeaways as bullet points.',
-    '3. Include any actionable steps separately if applicable.',
-    '',
-    'Transcript:',
-    trimmedTranscript
-  ].join('\n');
-};
+  const safeTitle = title?.trim() || 'Untitled video';
+  const preferences = {
+    overview_sentence_count: sanitizeNumber(settings.overviewSentences, DEFAULT_SETTINGS.overviewSentences, 1, 10),
+    include_takeaways: Boolean(settings.includeTakeaways),
+    include_action_steps: Boolean(settings.includeActionSteps),
+    response_language: settings.responseLanguage?.trim() || DEFAULT_SETTINGS.responseLanguage
+  };
 
-const fetchTranscript = async (videoUrl) => {
+  const instructions = [`Provide a concise overview in ${preferences.overview_sentence_count} sentence(s).`];
+  if (preferences.include_takeaways) {
+    instructions.push('List the main takeaways as bullet points.');
+  }
+  if (preferences.include_action_steps) {
+    instructions.push('Highlight actionable steps separately.');
+  }
+
+  if (settings.customInstructions) {
+    const customLines = settings.customInstructions
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    instructions.push(...customLines);
+  }
+
+  const payload = {
+    task: 'summarize_youtube_video',
+    format: 'json',
+    metadata: {
+      generated_at: new Date().toISOString(),
+      source: 'youtube-transcript-summarizer-extension',
+      transcript_source: 'glasp'
+    },
+    preferences,
+    video: {
+      title: safeTitle,
+      url
+    },
+    instructions,
+    transcript: trimmedTranscript
+  };
+
+  return JSON.stringify(payload, null, 2);
+}
+
+async function fetchTranscript(videoUrl) {
   if (!chrome?.runtime?.sendMessage) {
     throw new Error('chrome.runtime.sendMessage is unavailable.');
   }
@@ -130,45 +360,603 @@ const fetchTranscript = async (videoUrl) => {
       reject(new Error(errorMessage));
     });
   });
-};
+}
 
-const getCanonicalVideoUrl = () => {
-  const videoId = getCurrentVideoId();
-  if (!videoId) {
-    return null;
+async function openChatGPT(prompt, preferredHost) {
+  if (!chrome?.runtime?.sendMessage) {
+    throw new Error('chrome.runtime.sendMessage is unavailable.');
   }
 
-  return `https://www.youtube.com/watch?v=${videoId}`;
-};
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage({ type: 'openChatGPT', prompt, preferredHost }, (response) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message || 'Unexpected extension error.'));
+        return;
+      }
 
-const getCurrentVideoId = () => {
-  const urlVideoId = new URLSearchParams(window.location.search).get('v');
-  if (urlVideoId) {
-    return urlVideoId;
+      if (response?.status === 'error') {
+        reject(new Error(response.error || 'Unable to open ChatGPT.'));
+        return;
+      }
+
+      resolve();
+    });
+  });
+}
+
+function ensureGlobalStyles() {
+  if (document.getElementById(STYLE_ELEMENT_ID)) {
+    return;
   }
 
-  const playerElement = document.querySelector('ytd-player');
-  const player = playerElement?.player_ || playerElement;
+  const style = document.createElement('style');
+  style.id = STYLE_ELEMENT_ID;
+  style.textContent = `
+    #${SHORTS_CONTAINER_ID} {
+      position: fixed;
+      top: 96px;
+      right: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      z-index: 2147480000;
+    }
 
-  if (player?.getVideoData) {
+    #${SHORTS_CONTAINER_ID} button {
+      font: inherit;
+      border-radius: 999px;
+      border: 1px solid var(--yt-spec-outline, rgba(0, 0, 0, 0.2));
+      padding: 8px 16px;
+      cursor: pointer;
+      background: var(--yt-spec-base-background, #ffffff);
+      color: var(--yt-spec-text-primary, #0f0f0f);
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    #${SHORTS_CONTAINER_ID} button:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.24);
+    }
+
+    #${SHORTS_CONTAINER_ID} button:disabled {
+      opacity: 0.65;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    }
+
+    #${SHORTS_CONTAINER_ID} .ytlm-settings-toggle {
+      background: var(--yt-spec-10-percent-layer, rgba(0, 0, 0, 0.05));
+    }
+
+    .ytlm-secondary-action {
+      border-radius: 999px;
+      border: 1px solid var(--yt-spec-outline, rgba(0, 0, 0, 0.2));
+      background: transparent;
+      color: var(--yt-spec-text-primary, #0f0f0f);
+      padding: 6px 14px;
+      cursor: pointer;
+    }
+
+    #${SETTINGS_PANEL_ID} {
+      position: fixed;
+      inset: 0;
+      display: none;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0, 0, 0, 0.45);
+      z-index: 2147483600;
+    }
+
+    #${SETTINGS_PANEL_ID}.ytlm-visible {
+      display: flex;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-settings-modal {
+      position: relative;
+      width: min(420px, calc(100% - 32px));
+      max-height: 80vh;
+      overflow-y: auto;
+      background: var(--yt-spec-base-background, #ffffff);
+      color: var(--yt-spec-text-primary, #0f0f0f);
+      border-radius: 16px;
+      box-shadow: 0 20px 48px rgba(0, 0, 0, 0.35);
+      padding: 24px 24px 16px;
+      font-family: Roboto, Arial, sans-serif;
+    }
+
+    #${SETTINGS_PANEL_ID} h2 {
+      margin: 0 0 8px;
+      font-size: 20px;
+      font-weight: 600;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-settings-description {
+      margin: 0 0 16px;
+      font-size: 14px;
+      color: var(--yt-spec-text-secondary, #606060);
+    }
+
+    #${SETTINGS_PANEL_ID} form {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    #${SETTINGS_PANEL_ID} label {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      font-size: 14px;
+    }
+
+    #${SETTINGS_PANEL_ID} input[type="text"],
+    #${SETTINGS_PANEL_ID} input[type="number"],
+    #${SETTINGS_PANEL_ID} select,
+    #${SETTINGS_PANEL_ID} textarea {
+      font: inherit;
+      padding: 6px 10px;
+      border-radius: 8px;
+      border: 1px solid var(--yt-spec-outline, rgba(0, 0, 0, 0.2));
+      background: var(--yt-spec-base-background, #ffffff);
+      color: inherit;
+    }
+
+    #${SETTINGS_PANEL_ID} textarea {
+      min-height: 80px;
+      resize: vertical;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-checkbox {
+      flex-direction: row;
+      align-items: center;
+      gap: 8px;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-checkbox span {
+      flex: 1;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-settings-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 8px;
+      margin-top: 8px;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-primary {
+      background: var(--yt-spec-brand-background-solid, #065fd4);
+      color: #ffffff;
+      border: none;
+      border-radius: 999px;
+      padding: 8px 18px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-primary:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-secondary {
+      background: transparent;
+      color: inherit;
+      border: 1px solid var(--yt-spec-outline, rgba(0, 0, 0, 0.2));
+      border-radius: 999px;
+      padding: 8px 18px;
+      cursor: pointer;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-settings-status {
+      margin: 12px 0 0;
+      min-height: 18px;
+      font-size: 13px;
+      color: var(--yt-spec-text-secondary, #606060);
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-settings-status.ytlm-error {
+      color: #d93025;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-close-button {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      border: none;
+      background: transparent;
+      font-size: 22px;
+      line-height: 1;
+      cursor: pointer;
+      color: inherit;
+    }
+
+    #${SETTINGS_PANEL_ID} .ytlm-close-button:hover {
+      opacity: 0.75;
+    }
+  `;
+
+  const appendStyle = () => {
+    const target = document.head || document.documentElement;
+    if (target && !style.isConnected) {
+      target.appendChild(style);
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', appendStyle, { once: true });
+  }
+
+  appendStyle();
+}
+
+async function ensureSettingsLoaded() {
+  if (settingsLoaded) {
+    return currentSettings;
+  }
+
+  if (settingsLoadPromise) {
+    return settingsLoadPromise;
+  }
+
+  settingsLoadPromise = (async () => {
     try {
-      const videoData = player.getVideoData();
-      return videoData?.video_id || videoData?.videoId || null;
+      const loaded = await loadSettingsFromStorage();
+      currentSettings = sanitizeSettings(loaded);
+      settingsLoaded = true;
+      return currentSettings;
     } catch (error) {
-      console.debug('Failed to read video data from player.', error);
+      console.error('Failed to load settings', error);
+      currentSettings = { ...DEFAULT_SETTINGS };
+      settingsLoaded = true;
+      return currentSettings;
+    } finally {
+      settingsLoadPromise = null;
+    }
+  })();
+
+  return settingsLoadPromise;
+}
+
+async function loadSettingsFromStorage() {
+  const storageArea = chrome?.storage?.sync || chrome?.storage?.local;
+  if (!storageArea) {
+    return { ...DEFAULT_SETTINGS };
+  }
+
+  const stored = await storageArea.get(SETTINGS_STORAGE_KEY);
+  return stored?.[SETTINGS_STORAGE_KEY] || { ...DEFAULT_SETTINGS };
+}
+
+async function saveSettings(updatedSettings) {
+  currentSettings = sanitizeSettings(updatedSettings);
+  settingsLoaded = true;
+
+  const storageArea = chrome?.storage?.sync || chrome?.storage?.local;
+  if (!storageArea) {
+    return currentSettings;
+  }
+
+  await storageArea.set({ [SETTINGS_STORAGE_KEY]: currentSettings });
+  return currentSettings;
+}
+
+function sanitizeSettings(raw) {
+  const settings = { ...DEFAULT_SETTINGS };
+  if (!raw || typeof raw !== 'object') {
+    return settings;
+  }
+
+  settings.preferredChatHost = sanitizeHost(raw.preferredChatHost, DEFAULT_SETTINGS.preferredChatHost);
+  settings.overviewSentences = sanitizeNumber(
+    raw.overviewSentences,
+    DEFAULT_SETTINGS.overviewSentences,
+    1,
+    10
+  );
+  settings.includeTakeaways = sanitizeBoolean(raw.includeTakeaways, DEFAULT_SETTINGS.includeTakeaways);
+  settings.includeActionSteps = sanitizeBoolean(raw.includeActionSteps, DEFAULT_SETTINGS.includeActionSteps);
+  settings.responseLanguage = sanitizeString(raw.responseLanguage, DEFAULT_SETTINGS.responseLanguage);
+  settings.customInstructions = sanitizeMultilineString(raw.customInstructions, DEFAULT_SETTINGS.customInstructions);
+
+  return settings;
+}
+
+function sanitizeHost(value, fallback) {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'chat.openai.com') {
+      return 'chat.openai.com';
+    }
+    if (normalized === 'chatgpt.com') {
+      return 'chatgpt.com';
     }
   }
+  return fallback;
+}
 
-  return playerElement?.__data?.playerResponse?.videoDetails?.videoId || null;
-};
+function sanitizeNumber(value, fallback, min, max) {
+  const numeric = Number.parseInt(value, 10);
+  if (Number.isNaN(numeric)) {
+    return fallback;
+  }
+  const clamped = Math.min(Math.max(numeric, min), max);
+  return clamped;
+}
 
-const observer = new MutationObserver(() => addButtonIfNeeded());
-observer.observe(document.body, { childList: true, subtree: true });
+function sanitizeBoolean(value, fallback) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return fallback;
+}
 
-window.addEventListener('yt-navigate-finish', () => {
+function sanitizeString(value, fallback) {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function sanitizeMultilineString(value, fallback) {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+  return value.replace(/\s+$/, '');
+}
+
+function ensureSettingsPanel() {
+  if (settingsPanelRefs) {
+    return settingsPanelRefs;
+  }
+
+  const panel = document.createElement('div');
+  panel.id = SETTINGS_PANEL_ID;
+  panel.className = 'ytlm-settings-panel';
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'true');
+  panel.setAttribute('aria-hidden', 'true');
+
+  const modal = document.createElement('div');
+  modal.className = 'ytlm-settings-modal';
+
+  const closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.className = 'ytlm-close-button';
+  closeButton.setAttribute('aria-label', 'Close settings');
+  closeButton.textContent = '×';
+  closeButton.addEventListener('click', closeSettingsPanel);
+
+  const heading = document.createElement('h2');
+  heading.textContent = 'Extension Settings';
+
+  const description = document.createElement('p');
+  description.className = 'ytlm-settings-description';
+  description.textContent = 'Adjust how prompts are generated and which ChatGPT domain to use.';
+
+  const form = document.createElement('form');
+
+  const hostLabel = document.createElement('label');
+  hostLabel.textContent = 'Preferred ChatGPT domain';
+  const hostSelect = document.createElement('select');
+  hostSelect.name = 'preferredChatHost';
+  const optionChatGPT = document.createElement('option');
+  optionChatGPT.value = 'chatgpt.com';
+  optionChatGPT.textContent = 'chatgpt.com';
+  const optionChatOpenAI = document.createElement('option');
+  optionChatOpenAI.value = 'chat.openai.com';
+  optionChatOpenAI.textContent = 'chat.openai.com';
+  hostSelect.append(optionChatGPT, optionChatOpenAI);
+  hostLabel.appendChild(hostSelect);
+
+  const overviewLabel = document.createElement('label');
+  overviewLabel.textContent = 'Overview sentence count';
+  const overviewInput = document.createElement('input');
+  overviewInput.type = 'number';
+  overviewInput.name = 'overviewSentences';
+  overviewInput.min = '1';
+  overviewInput.max = '10';
+  overviewInput.step = '1';
+  overviewLabel.appendChild(overviewInput);
+
+  const takeawaysLabel = document.createElement('label');
+  takeawaysLabel.className = 'ytlm-checkbox';
+  const takeawaysCheckbox = document.createElement('input');
+  takeawaysCheckbox.type = 'checkbox';
+  takeawaysCheckbox.name = 'includeTakeaways';
+  const takeawaysText = document.createElement('span');
+  takeawaysText.textContent = 'Include key takeaways list';
+  takeawaysLabel.append(takeawaysCheckbox, takeawaysText);
+
+  const actionLabel = document.createElement('label');
+  actionLabel.className = 'ytlm-checkbox';
+  const actionCheckbox = document.createElement('input');
+  actionCheckbox.type = 'checkbox';
+  actionCheckbox.name = 'includeActionSteps';
+  const actionText = document.createElement('span');
+  actionText.textContent = 'Include actionable steps';
+  actionLabel.append(actionCheckbox, actionText);
+
+  const languageLabel = document.createElement('label');
+  languageLabel.textContent = 'Preferred response language';
+  const languageInput = document.createElement('input');
+  languageInput.type = 'text';
+  languageInput.name = 'responseLanguage';
+  languageLabel.appendChild(languageInput);
+
+  const instructionsLabel = document.createElement('label');
+  instructionsLabel.textContent = 'Additional instructions (one per line)';
+  const instructionsTextarea = document.createElement('textarea');
+  instructionsTextarea.name = 'customInstructions';
+  instructionsLabel.appendChild(instructionsTextarea);
+
+  const actionsRow = document.createElement('div');
+  actionsRow.className = 'ytlm-settings-actions';
+  const saveButton = document.createElement('button');
+  saveButton.type = 'submit';
+  saveButton.className = 'ytlm-primary';
+  saveButton.textContent = 'Save';
+  const closeActionButton = document.createElement('button');
+  closeActionButton.type = 'button';
+  closeActionButton.className = 'ytlm-secondary';
+  closeActionButton.textContent = 'Close';
+  closeActionButton.addEventListener('click', closeSettingsPanel);
+  actionsRow.append(saveButton, closeActionButton);
+
+  const status = document.createElement('p');
+  status.className = 'ytlm-settings-status';
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+
+  form.append(
+    hostLabel,
+    overviewLabel,
+    takeawaysLabel,
+    actionLabel,
+    languageLabel,
+    instructionsLabel,
+    actionsRow
+  );
+
+  modal.append(closeButton, heading, description, form, status);
+  panel.appendChild(modal);
+  panel.addEventListener('click', (event) => {
+    if (event.target === panel) {
+      closeSettingsPanel();
+    }
+  });
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    await handleSettingsSubmit({
+      hostSelect,
+      overviewInput,
+      takeawaysCheckbox,
+      actionCheckbox,
+      languageInput,
+      instructionsTextarea,
+      saveButton,
+      status
+    });
+  });
+
+  panel.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeSettingsPanel();
+    }
+  });
+
+  document.body.appendChild(panel);
+
+  settingsPanelRefs = {
+    panel,
+    form,
+    status,
+    elements: {
+      hostSelect,
+      overviewInput,
+      takeawaysCheckbox,
+      actionCheckbox,
+      languageInput,
+      instructionsTextarea
+    },
+    saveButton
+  };
+
+  return settingsPanelRefs;
+}
+
+async function openSettingsPanel() {
+  const refs = ensureSettingsPanel();
+  await ensureSettingsLoaded();
+
+  populateSettingsForm(refs.elements, currentSettings);
+  refs.status.textContent = '';
+  refs.status.classList.remove('ytlm-error');
+
+  refs.panel.classList.add('ytlm-visible');
+  refs.panel.setAttribute('aria-hidden', 'false');
+
+  lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
   setTimeout(() => {
-    addButtonIfNeeded();
-  }, 1000);
-});
+    refs.elements.hostSelect.focus({ preventScroll: true });
+  }, 50);
+}
 
-addButtonIfNeeded();
+function closeSettingsPanel() {
+  if (!settingsPanelRefs) {
+    return;
+  }
+  settingsPanelRefs.panel.classList.remove('ytlm-visible');
+  settingsPanelRefs.panel.setAttribute('aria-hidden', 'true');
+  settingsPanelRefs.panel.blur();
+
+  if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+    try {
+      lastFocusedElement.focus({ preventScroll: true });
+    } catch (error) {
+      lastFocusedElement.focus();
+    }
+  }
+  lastFocusedElement = null;
+}
+
+function populateSettingsForm(elements, settings) {
+  elements.hostSelect.value = settings.preferredChatHost;
+  elements.overviewInput.value = settings.overviewSentences;
+  elements.takeawaysCheckbox.checked = settings.includeTakeaways;
+  elements.actionCheckbox.checked = settings.includeActionSteps;
+  elements.languageInput.value = settings.responseLanguage;
+  elements.instructionsTextarea.value = settings.customInstructions;
+}
+
+async function handleSettingsSubmit({
+  hostSelect,
+  overviewInput,
+  takeawaysCheckbox,
+  actionCheckbox,
+  languageInput,
+  instructionsTextarea,
+  saveButton,
+  status
+}) {
+  const updated = {
+    preferredChatHost: hostSelect.value,
+    overviewSentences: sanitizeNumber(overviewInput.value, currentSettings.overviewSentences, 1, 10),
+    includeTakeaways: takeawaysCheckbox.checked,
+    includeActionSteps: actionCheckbox.checked,
+    responseLanguage: sanitizeString(languageInput.value, currentSettings.responseLanguage),
+    customInstructions: instructionsTextarea.value
+  };
+
+  setStatusMessage(status, 'Saving…', false);
+  saveButton.disabled = true;
+
+  try {
+    await saveSettings(updated);
+    setStatusMessage(status, 'Settings saved.', false);
+  } catch (error) {
+    console.error('Failed to save settings', error);
+    setStatusMessage(status, 'Failed to save settings. Please try again.', true);
+  } finally {
+    saveButton.disabled = false;
+  }
+}
+
+function setStatusMessage(statusElement, message, isError) {
+  statusElement.textContent = message;
+  if (isError) {
+    statusElement.classList.add('ytlm-error');
+  } else {
+    statusElement.classList.remove('ytlm-error');
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -5,11 +5,13 @@
   "description": "Adds a button to YouTube videos to send the transcript to ChatGPT for summarization.",
   "permissions": [
     "tabs",
-    "scripting"
+    "scripting",
+    "storage"
   ],
   "host_permissions": [
     "https://www.youtube.com/*",
     "https://chat.openai.com/*",
+    "https://chatgpt.com/*",
     "https://glasp.co/*"
   ],
   "background": {
@@ -17,7 +19,10 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.youtube.com/watch*"],
+      "matches": [
+        "https://www.youtube.com/watch*",
+        "https://www.youtube.com/shorts/*"
+      ],
       "js": ["contentScript.js"],
       "run_at": "document_idle"
     }


### PR DESCRIPTION
## Summary
- persist pending ChatGPT prompts in storage-backed background logic and retry injection on chat.openai.com or chatgpt.com
- fetch Glasp transcripts through a hidden reader tab, parse the body text, and auto-send messages after injection
- generate JSON-formatted prompts with a configurable settings modal, plus add a Shorts overlay button
- update the manifest for storage permission, chatgpt.com host access, and Shorts content script coverage

## Testing
- Not run (extension code)


------
https://chatgpt.com/codex/tasks/task_e_68cf8f0d38d48320a2e2c07129f814c4