### PR TITLE
Refactor action button into shared menu

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,11 +1,10 @@
 const WATCH_BUTTON_ID = 'ytlm-summarize-btn';
-const WATCH_SETTINGS_BUTTON_ID = 'ytlm-settings-btn';
 const SHORTS_CONTAINER_ID = 'ytlm-floating-controls';
 const SHORTS_BUTTON_ID = 'ytlm-shorts-summarize-btn';
-const SHORTS_SETTINGS_BUTTON_ID = 'ytlm-floating-settings-btn';
 const SETTINGS_PANEL_ID = 'ytlm-settings-panel';
 const SETTINGS_STORAGE_KEY = 'ytlmSettingsV1';
 const STYLE_ELEMENT_ID = 'ytlm-shared-styles';
+const ACTION_MENU_VISIBLE_CLASS = 'ytlm-visible';
 
 const BUTTON_LABELS = {
   idle: 'Summarize with ChatGPT',
@@ -28,6 +27,8 @@ let settingsLoadPromise = null;
 let settingsPanelRefs = null;
 let lastFocusedElement = null;
 let pendingButtonUpdate = false;
+let activeMenuState = null;
+let menuDismissListenersAttached = false;
 
 ensureGlobalStyles();
 ensureSettingsLoaded().catch((error) => console.error('Failed to pre-load settings', error));
@@ -58,6 +59,7 @@ window.addEventListener('yt-navigate-finish', () => {
 });
 
 function addOrUpdateButtons() {
+  closeActiveMenu();
   ensureWatchButtons();
   ensureShortsButtons();
 }
@@ -94,49 +96,17 @@ function ensureWatchButtons() {
     return;
   }
 
-  let summarizeButton = document.getElementById(WATCH_BUTTON_ID);
-  if (!summarizeButton) {
-    summarizeButton = document.createElement('button');
-    summarizeButton.id = WATCH_BUTTON_ID;
-    summarizeButton.type = 'button';
-    summarizeButton.textContent = BUTTON_LABELS.idle;
-    summarizeButton.setAttribute('aria-label', BUTTON_LABELS.idle);
+  const referenceButton =
+    container.querySelector('button.yt-spec-button-shape-next') || container.querySelector('button');
 
-    const referenceButton =
-      container.querySelector('button.yt-spec-button-shape-next') || container.querySelector('button');
-
-    if (referenceButton && referenceButton.className) {
-      summarizeButton.className = referenceButton.className;
-    } else {
-      summarizeButton.className =
-        'yt-spec-button-shape-next yt-spec-button-shape-next--outline yt-spec-button-shape-next--size-m';
-    }
-
-    summarizeButton.style.marginLeft = '8px';
-    summarizeButton.addEventListener('click', () => handleSummarize(summarizeButton));
-    container.appendChild(summarizeButton);
-  }
+  const summarizeButton = ensureContextualActionButton({
+    id: WATCH_BUTTON_ID,
+    container,
+    context: 'watch',
+    referenceButton
+  });
 
   setButtonState(summarizeButton, summarizeButton.dataset.ytlmState || 'idle');
-
-  let settingsButton = document.getElementById(WATCH_SETTINGS_BUTTON_ID);
-  if (!settingsButton) {
-    settingsButton = document.createElement('button');
-    settingsButton.id = WATCH_SETTINGS_BUTTON_ID;
-    settingsButton.type = 'button';
-    settingsButton.textContent = 'Settings';
-    settingsButton.setAttribute('aria-label', 'Open extension settings');
-
-    if (summarizeButton && summarizeButton.className) {
-      settingsButton.className = summarizeButton.className;
-    } else {
-      settingsButton.className = 'ytlm-secondary-action';
-    }
-
-    settingsButton.style.marginLeft = '8px';
-    settingsButton.addEventListener('click', openSettingsPanel);
-    container.appendChild(settingsButton);
-  }
 }
 
 function ensureShortsButtons() {
@@ -147,6 +117,7 @@ function ensureShortsButtons() {
     if (container) {
       container.remove();
     }
+    removeActionMenu(SHORTS_BUTTON_ID);
     return;
   }
 
@@ -159,31 +130,334 @@ function ensureShortsButtons() {
     document.body.appendChild(container);
   }
 
-  let summarizeButton = document.getElementById(SHORTS_BUTTON_ID);
-  if (!summarizeButton) {
-    summarizeButton = document.createElement('button');
-    summarizeButton.id = SHORTS_BUTTON_ID;
-    summarizeButton.type = 'button';
-    summarizeButton.className = 'ytlm-floating-button';
-    summarizeButton.textContent = BUTTON_LABELS.idle;
-    summarizeButton.setAttribute('aria-label', BUTTON_LABELS.idle);
-    summarizeButton.addEventListener('click', () => handleSummarize(summarizeButton));
-    container.appendChild(summarizeButton);
-  }
+  const summarizeButton = ensureContextualActionButton({
+    id: SHORTS_BUTTON_ID,
+    container,
+    context: 'shorts'
+  });
 
   setButtonState(summarizeButton, summarizeButton.dataset.ytlmState || 'idle');
+}
 
-  let settingsButton = document.getElementById(SHORTS_SETTINGS_BUTTON_ID);
-  if (!settingsButton) {
-    settingsButton = document.createElement('button');
-    settingsButton.id = SHORTS_SETTINGS_BUTTON_ID;
-    settingsButton.type = 'button';
-    settingsButton.className = 'ytlm-floating-button ytlm-settings-toggle';
-    settingsButton.textContent = 'Settings';
-    settingsButton.setAttribute('aria-label', 'Open extension settings');
-    settingsButton.addEventListener('click', openSettingsPanel);
-    container.appendChild(settingsButton);
+function ensureContextualActionButton({ id, container, context, referenceButton }) {
+  let button = document.getElementById(id);
+  if (!button) {
+    button = document.createElement('button');
+    button.id = id;
+    button.type = 'button';
+    button.dataset.ytlmBusy = 'false';
+    button.dataset.ytlmState = 'idle';
+    button.dataset.ytlmContext = context;
+    button.setAttribute('aria-haspopup', 'menu');
+    button.setAttribute('aria-expanded', 'false');
+
+    if (context === 'watch') {
+      if (referenceButton && referenceButton.className) {
+        button.className = referenceButton.className;
+      } else {
+        button.className =
+          'yt-spec-button-shape-next yt-spec-button-shape-next--outline yt-spec-button-shape-next--size-m';
+      }
+      button.classList.add('ytlm-action-button', 'ytlm-action-button--watch');
+    } else {
+      button.className = 'ytlm-action-button ytlm-action-button--shorts';
+    }
+
+    const icon = document.createElement('span');
+    icon.className = 'ytlm-button-icon';
+    icon.setAttribute('aria-hidden', 'true');
+
+    const label = document.createElement('span');
+    label.className = 'ytlm-button-label';
+    label.textContent = BUTTON_LABELS.idle;
+
+    button.append(icon, label);
+    button.setAttribute('aria-label', BUTTON_LABELS.idle);
+
+    container.appendChild(button);
+  } else {
+    button.dataset.ytlmContext = context;
+
+    if (context === 'watch') {
+      button.classList.add('ytlm-action-button', 'ytlm-action-button--watch');
+    } else {
+      button.classList.add('ytlm-action-button', 'ytlm-action-button--shorts');
+    }
   }
+
+  if (!button.querySelector('.ytlm-button-icon')) {
+    const icon = document.createElement('span');
+    icon.className = 'ytlm-button-icon';
+    icon.setAttribute('aria-hidden', 'true');
+    button.prepend(icon);
+  }
+
+  if (!button.querySelector('.ytlm-button-label')) {
+    const label = document.createElement('span');
+    label.className = 'ytlm-button-label';
+    label.textContent = BUTTON_LABELS.idle;
+    button.appendChild(label);
+  }
+
+  if (!button.dataset.ytlmMenuBound) {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      toggleActionMenu(button, context);
+    });
+    button.dataset.ytlmMenuBound = 'true';
+  }
+
+  const menu = ensureActionMenu(button, context);
+  button.setAttribute('aria-controls', menu.id);
+
+  if (!button.dataset.ytlmBusy) {
+    button.dataset.ytlmBusy = 'false';
+  }
+
+  if (!button.dataset.ytlmState) {
+    button.dataset.ytlmState = 'idle';
+  }
+
+  return button;
+}
+
+function ensureActionMenu(button, context) {
+  const menuId = `${button.id}-menu`;
+  let menu = document.getElementById(menuId);
+
+  if (!menu) {
+    menu = document.createElement('div');
+    menu.id = menuId;
+    menu.className = 'ytlm-action-menu';
+    menu.setAttribute('role', 'menu');
+    menu.dataset.ytlmOpen = 'false';
+
+    const summarizeItem = document.createElement('button');
+    summarizeItem.type = 'button';
+    summarizeItem.className = 'ytlm-action-menu__item';
+    summarizeItem.textContent = 'Summarize';
+    summarizeItem.setAttribute('role', 'menuitem');
+    summarizeItem.dataset.action = 'summarize';
+    summarizeItem.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const currentButton = document.getElementById(menu.dataset.ytlmButtonId);
+      if (currentButton) {
+        closeActionMenu(menu, currentButton);
+        handleSummarize(currentButton);
+      } else {
+        closeActionMenu(menu, null);
+      }
+    });
+
+    const settingsItem = document.createElement('button');
+    settingsItem.type = 'button';
+    settingsItem.className = 'ytlm-action-menu__item';
+    settingsItem.textContent = 'Settings';
+    settingsItem.setAttribute('role', 'menuitem');
+    settingsItem.dataset.action = 'settings';
+    settingsItem.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const currentButton = document.getElementById(menu.dataset.ytlmButtonId);
+      closeActionMenu(menu, currentButton || null);
+      openSettingsPanel().catch((error) => console.error('Failed to open settings panel', error));
+    });
+
+    menu.append(summarizeItem, settingsItem);
+    document.body.appendChild(menu);
+  }
+
+  menu.dataset.ytlmButtonId = button.id;
+  menu.dataset.ytlmContext = context;
+  menu.setAttribute('aria-labelledby', button.id);
+
+  return menu;
+}
+
+function toggleActionMenu(button, context) {
+  const menu = ensureActionMenu(button, context);
+
+  if (menu.dataset.ytlmOpen === 'true') {
+    closeActionMenu(menu, button);
+  } else {
+    openActionMenu(menu, button, context);
+  }
+}
+
+function openActionMenu(menu, button, context) {
+  if (activeMenuState && activeMenuState.menu !== menu) {
+    closeActionMenu(activeMenuState.menu, activeMenuState.button);
+  }
+
+  activeMenuState = { menu, button };
+  menu.dataset.ytlmOpen = 'true';
+  menu.classList.add(ACTION_MENU_VISIBLE_CLASS);
+  menu.style.visibility = 'hidden';
+  button.setAttribute('aria-expanded', 'true');
+
+  positionActionMenu(menu, button, context);
+
+  menu.style.visibility = '';
+  attachMenuDismissListeners();
+}
+
+function closeActionMenu(menu, button) {
+  if (!menu) {
+    return;
+  }
+
+  menu.dataset.ytlmOpen = 'false';
+  menu.classList.remove(ACTION_MENU_VISIBLE_CLASS);
+  menu.style.top = '';
+  menu.style.left = '';
+  menu.style.visibility = '';
+
+  if (button) {
+    button.setAttribute('aria-expanded', 'false');
+  }
+
+  if (activeMenuState && activeMenuState.menu === menu) {
+    activeMenuState = null;
+    detachMenuDismissListeners();
+  }
+}
+
+function closeActiveMenu() {
+  if (!activeMenuState) {
+    return;
+  }
+
+  const { menu, button } = activeMenuState;
+  closeActionMenu(menu, button);
+}
+
+function removeActionMenu(buttonId) {
+  const menu = document.getElementById(`${buttonId}-menu`);
+  if (!menu) {
+    return;
+  }
+
+  const button = document.getElementById(buttonId);
+  closeActionMenu(menu, button || null);
+  menu.remove();
+}
+
+function positionActionMenu(menu, button, context) {
+  const rect = button.getBoundingClientRect();
+  const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+  const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+
+  // Force layout to measure size.
+  const menuRect = menu.getBoundingClientRect();
+
+  let top;
+  let left;
+
+  if (context === 'shorts') {
+    top = rect.top + rect.height / 2 - menuRect.height / 2;
+    left = rect.left - menuRect.width - 12;
+
+    if (left < 8) {
+      left = rect.right + 12;
+    }
+  } else {
+    top = rect.bottom + 8;
+    left = rect.left;
+  }
+
+  if (top + menuRect.height > viewportHeight - 8) {
+    top = Math.max(rect.top - menuRect.height - 8, viewportHeight - menuRect.height - 8);
+  }
+
+  if (top < 8) {
+    top = 8;
+  }
+
+  if (left + menuRect.width > viewportWidth - 8) {
+    left = Math.max(viewportWidth - menuRect.width - 8, 8);
+  }
+
+  if (left < 8) {
+    left = 8;
+  }
+
+  menu.style.top = `${Math.round(top)}px`;
+  menu.style.left = `${Math.round(left)}px`;
+}
+
+function attachMenuDismissListeners() {
+  if (menuDismissListenersAttached) {
+    return;
+  }
+
+  menuDismissListenersAttached = true;
+  document.addEventListener('pointerdown', handleMenuDismissPointer, true);
+  document.addEventListener('keydown', handleMenuDismissKeydown, true);
+  window.addEventListener('resize', handleMenuDismissResize, true);
+  window.addEventListener('scroll', handleMenuScroll, true);
+}
+
+function detachMenuDismissListeners() {
+  if (!menuDismissListenersAttached) {
+    return;
+  }
+
+  menuDismissListenersAttached = false;
+  document.removeEventListener('pointerdown', handleMenuDismissPointer, true);
+  document.removeEventListener('keydown', handleMenuDismissKeydown, true);
+  window.removeEventListener('resize', handleMenuDismissResize, true);
+  window.removeEventListener('scroll', handleMenuScroll, true);
+}
+
+function handleMenuDismissPointer(event) {
+  if (!activeMenuState) {
+    return;
+  }
+
+  const { menu, button } = activeMenuState;
+  const target = event.target;
+
+  if (menu.contains(target) || button.contains(target)) {
+    return;
+  }
+
+  closeActionMenu(menu, button);
+}
+
+function handleMenuDismissKeydown(event) {
+  if (!activeMenuState) {
+    return;
+  }
+
+  if (event.key === 'Escape' || event.key === 'Esc') {
+    const { menu, button } = activeMenuState;
+    closeActionMenu(menu, button);
+    if (button && typeof button.focus === 'function') {
+      try {
+        button.focus({ preventScroll: true });
+      } catch (error) {
+        button.focus();
+      }
+    }
+  }
+}
+
+function handleMenuDismissResize() {
+  closeActiveMenu();
+}
+
+function handleMenuScroll(event) {
+  if (!activeMenuState) {
+    return;
+  }
+
+  const { menu } = activeMenuState;
+  if (menu.contains(event.target)) {
+    return;
+  }
+
+  closeActiveMenu();
 }
 
 async function handleSummarize(button) {
@@ -229,14 +503,31 @@ function setButtonState(button, state) {
     return;
   }
   const label = BUTTON_LABELS[state] || BUTTON_LABELS.idle;
+  const isIdle = state === 'idle';
   button.dataset.ytlmState = state;
-  if (state === 'idle') {
-    button.disabled = false;
+  button.dataset.ytlmBusy = (!isIdle).toString();
+  button.classList.toggle('ytlm-busy', !isIdle);
+
+  const labelElement = button.querySelector('.ytlm-button-label');
+  if (labelElement) {
+    labelElement.textContent = label;
   } else {
-    button.disabled = true;
+    button.textContent = label;
   }
-  button.textContent = label;
+
   button.setAttribute('aria-label', label);
+
+  const menuId = button.getAttribute('aria-controls');
+  if (menuId) {
+    const menu = document.getElementById(menuId);
+    if (menu) {
+      const summarizeItem = menu.querySelector('[data-action="summarize"]');
+      if (summarizeItem) {
+        summarizeItem.disabled = !isIdle;
+        summarizeItem.textContent = isIdle ? 'Summarize' : 'Summarizing…';
+      }
+    }
+  }
 }
 
 function resetButtonStates() {
@@ -427,45 +718,152 @@ function ensureGlobalStyles() {
       right: 16px;
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      gap: 12px;
       z-index: 2147480000;
+      pointer-events: none;
     }
 
-    #${SHORTS_CONTAINER_ID} button {
+    #${SHORTS_CONTAINER_ID} .ytlm-action-button {
+      pointer-events: auto;
+    }
+
+    .ytlm-action-button {
+      position: relative;
       font: inherit;
-      border-radius: 999px;
-      border: 1px solid var(--yt-spec-outline, rgba(0, 0, 0, 0.2));
-      padding: 8px 16px;
-      cursor: pointer;
+    }
+
+    .ytlm-action-button .ytlm-button-label {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
+      white-space: nowrap;
+    }
+
+    .ytlm-action-button .ytlm-button-icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .ytlm-action-button:focus-visible {
+      outline: 3px solid var(--yt-spec-brand-button-background, #065fd4);
+      outline-offset: 2px;
+    }
+
+    .ytlm-action-button--watch {
+      margin-left: 8px;
+    }
+
+    .ytlm-action-button--watch .ytlm-button-icon {
+      display: none;
+    }
+
+    .ytlm-action-button--watch.ytlm-busy .ytlm-button-label {
+      opacity: 0.8;
+    }
+
+    .ytlm-action-button--shorts {
+      width: 52px;
+      height: 52px;
+      border-radius: 50%;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      background: rgba(15, 15, 15, 0.9);
+      color: #ffffff;
+      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+      transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+    }
+
+    .ytlm-action-button--shorts:hover:not(.ytlm-busy) {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4);
+      background: rgba(15, 15, 15, 0.95);
+    }
+
+    .ytlm-action-button--shorts:active {
+      transform: translateY(0);
+    }
+
+    .ytlm-action-button--shorts .ytlm-button-label {
+      display: none;
+    }
+
+    .ytlm-action-button--shorts .ytlm-button-icon {
+      width: 26px;
+      height: 26px;
+      background-repeat: no-repeat;
+      background-position: center;
+      background-size: 24px 24px;
+      background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2.75a5.25 5.25 0 0 1 4.72 7.72A5.25 5.25 0 0 1 19 14.25 5.25 5.25 0 0 1 8.53 18.7 5.25 5.25 0 0 1 5 13.75a5.25 5.25 0 0 1 2.54-9.48"/><path d="M8.2 7.4 12 9.5l3.8-2.1"/><path d="M8.2 16.6v-4.2l-3.2-1.8"/><path d="M15.8 16.6v-4.2l3.2-1.8"/></svg>');
+    }
+
+    .ytlm-action-button--shorts.ytlm-busy {
+      cursor: progress;
+    }
+
+    .ytlm-action-button--shorts.ytlm-busy .ytlm-button-icon {
+      background-image: none;
+      border-radius: 50%;
+      border: 3px solid rgba(255, 255, 255, 0.35);
+      border-top-color: rgba(255, 255, 255, 0.95);
+      animation: ytlm-spin 1s linear infinite;
+    }
+
+    @keyframes ytlm-spin {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    .ytlm-action-menu {
+      position: fixed;
+      top: 0;
+      left: 0;
+      display: none;
+      flex-direction: column;
+      gap: 4px;
+      min-width: 160px;
+      padding: 8px;
+      border-radius: 12px;
       background: var(--yt-spec-base-background, #ffffff);
       color: var(--yt-spec-text-primary, #0f0f0f);
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 18px 48px rgba(0, 0, 0, 0.28);
+      border: 1px solid rgba(0, 0, 0, 0.08);
+      z-index: 2147483600;
     }
 
-    #${SHORTS_CONTAINER_ID} button:hover:not(:disabled) {
-      transform: translateY(-1px);
-      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.24);
+    .ytlm-action-menu.${ACTION_MENU_VISIBLE_CLASS} {
+      display: flex;
     }
 
-    #${SHORTS_CONTAINER_ID} button:disabled {
-      opacity: 0.65;
-      cursor: not-allowed;
-      transform: none;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
-    }
-
-    #${SHORTS_CONTAINER_ID} .ytlm-settings-toggle {
-      background: var(--yt-spec-10-percent-layer, rgba(0, 0, 0, 0.05));
-    }
-
-    .ytlm-secondary-action {
-      border-radius: 999px;
-      border: 1px solid var(--yt-spec-outline, rgba(0, 0, 0, 0.2));
+    .ytlm-action-menu__item {
+      font: inherit;
+      border: none;
       background: transparent;
-      color: var(--yt-spec-text-primary, #0f0f0f);
-      padding: 6px 14px;
+      color: inherit;
+      border-radius: 8px;
+      padding: 10px 12px;
+      text-align: left;
       cursor: pointer;
+      transition: background-color 0.18s ease, color 0.18s ease;
+    }
+
+    .ytlm-action-menu__item:hover:not(:disabled),
+    .ytlm-action-menu__item:focus-visible {
+      background: var(--yt-spec-10-percent-layer, rgba(0, 0, 0, 0.08));
+      outline: none;
+    }
+
+    .ytlm-action-menu__item:disabled {
+      cursor: not-allowed;
+      opacity: 0.55;
+    }
+
+    .ytlm-action-menu__item + .ytlm-action-menu__item {
+      margin-top: 2px;
     }
 
     #${SETTINGS_PANEL_ID} {


### PR DESCRIPTION
## Summary
- replace the separate watch/shorts button creation with a shared helper that mounts a single action button and dropdown menu in each context
- add menu lifecycle logic that triggers summarization or opens the settings panel, while keeping button state updates in sync
- refresh the stylesheet so the watch button blends with the action bar, the Shorts button shows the extension logo, and the popup menu is themed

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf9af8e20483209e586be619aec446