### PR TITLE
Skip watch buttons on Shorts pages

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -86,6 +86,20 @@ function scheduleButtonUpdate() {
 }
 
 function ensureWatchButtons() {
+  if (isShortsPage()) {
+    const existingWatchButton = document.getElementById(WATCH_BUTTON_ID);
+    if (existingWatchButton) {
+      existingWatchButton.remove();
+    }
+
+    const existingSettingsButton = document.getElementById(WATCH_SETTINGS_BUTTON_ID);
+    if (existingSettingsButton) {
+      existingSettingsButton.remove();
+    }
+
+    return;
+  }
+
   const container =
     document.querySelector('#top-row #actions #top-level-buttons-computed') ||
     document.querySelector('#top-level-buttons-computed');


### PR DESCRIPTION
## Summary
- prevent watch action-bar buttons from rendering while browsing YouTube Shorts
- remove any lingering watch buttons when navigating into Shorts so only floating controls remain

## Testing
- not run (extension changes require manual browser verification)


------
https://chatgpt.com/codex/tasks/task_e_68cf9af899748320a7c42f074e61161c