### PR TITLE
Fix transcript parsing when marketing header precedes transcript

### DIFF
--- a/background.js
+++ b/background.js
@@ -422,8 +422,8 @@ function parseTranscriptFromReaderText(pageText) {
   }
 
   const sanitized = pageText.replace(/\r/g, '\n').replace(/\u00a0/g, ' ');
-  const truncated = truncateMarketingContent(sanitized);
-  const transcriptSection = extractTranscriptSection(truncated).trim();
+  const transcriptCandidate = extractTranscriptSection(sanitized);
+  const transcriptSection = truncateMarketingContent(transcriptCandidate).trim();
 
   if (!transcriptSection) {
     throw new Error('Transcript data not found on Glasp for this video.');


### PR DESCRIPTION
## Summary
- ensure parseTranscriptFromReaderText extracts the transcript section before truncating marketing content so marketing headers do not remove transcripts

## Testing
- node <<'NODE' ... (Shorts and long-form transcript parsing checks)


------
https://chatgpt.com/codex/tasks/task_e_68d0a35c4e1c8320ad02539806e1cb91