### PR TITLE
Improve transcript sanitization to drop Glasp header

### DIFF
--- a/test/sanitizeTranscriptForPrompt.test.js
+++ b/test/sanitizeTranscriptForPrompt.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { sanitizeTranscriptForPrompt } = require('../contentScript.js');
+
+test('sanitizeTranscriptForPrompt removes Glasp header boilerplate', () => {
+  const rawTranscript = [
+    '& Summary',
+    'Share Video',
+    'Download .srt',
+    'Copy',
+    'Understanding AI in 2024',
+    'Understanding AI in 2024',
+    'Daniel.',
+    'Daniel.',
+    '',
+    'Daniel: Welcome back everyone.',
+    'Sarah: Thanks for having me!'
+  ].join('\r\n');
+
+  const sanitized = sanitizeTranscriptForPrompt(rawTranscript);
+
+  assert.strictEqual(
+    sanitized,
+    'Daniel: Welcome back everyone.\nSarah: Thanks for having me!'
+  );
+});


### PR DESCRIPTION
## Summary
- guard the content script's bootstrap logic so it only runs in the browser environment
- normalize transcripts by removing Glasp header UI lines, blank rows, and normalizing newlines before prompting
- add a node-based unit test that exercises the sanitization against a transcript containing the problematic header chunk

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68d0d2c2b5dc8320b85cd6a79509f5aa