### PR TITLE
Handle single-line Glasp headers in transcript sanitizer

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1306,6 +1306,7 @@ function sanitizeTranscriptForPrompt(transcript) {
     'notes',
     'my notes'
   ]);
+  const marketingKeywordFragments = ['share', 'video', 'download', 'copy', 'highlight', 'highlights', 'note', 'notes', 'transcript'];
   const isDownloadHeader = (headerKey) =>
     headerKey.startsWith('download ') && /(?:\.srt\b|\btranscript\b|\.txt\b|\btext\b)/.test(headerKey);
 
@@ -1339,10 +1340,15 @@ function sanitizeTranscriptForPrompt(transcript) {
       continue;
     }
 
+    const hasSummaryPrefix = headerKey && headerKey.startsWith('summary');
+    const containsMarketingKeyword =
+      headerKey && marketingKeywordFragments.some((keyword) => headerKey.includes(keyword));
+
     const isMarketingLine =
       !comparisonKey ||
       marketingPrefixes.some((pattern) => pattern.test(headerCandidate)) ||
-      (headerKey && (marketingExactMatches.has(headerKey) || isDownloadHeader(headerKey)));
+      (headerKey && (marketingExactMatches.has(headerKey) || isDownloadHeader(headerKey))) ||
+      (hasSummaryPrefix && (headerKey === 'summary' || containsMarketingKeyword));
     if (isMarketingLine) {
       startIndex += 1;
       continue;

--- a/test/sanitizeTranscriptForPrompt.test.js
+++ b/test/sanitizeTranscriptForPrompt.test.js
@@ -25,3 +25,18 @@ test('sanitizeTranscriptForPrompt removes Glasp header boilerplate', () => {
     'Daniel: Welcome back everyone.\nSarah: Thanks for having me!'
   );
 });
+
+test('sanitizeTranscriptForPrompt removes single-line Glasp header boilerplate', () => {
+  const rawTranscript = [
+    '& SummaryPOV: If Tag this to revisit later. Share VideoDownload .srtCopy',
+    'Daniel: Welcome back everyone.',
+    'Sarah: Thanks for having me!'
+  ].join('\n');
+
+  const sanitized = sanitizeTranscriptForPrompt(rawTranscript);
+
+  assert.strictEqual(
+    sanitized,
+    'Daniel: Welcome back everyone.\nSarah: Thanks for having me!'
+  );
+});


### PR DESCRIPTION
## Summary
- extend the transcript sanitizer to treat Glasp summary headers even when the marketing block is collapsed onto one line
- mark summary-prefixed headers with other marketing keywords as boilerplate so they are removed before prompting
- add a regression test that covers the single-line header scenario

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68d0d703c2dc832081617de23f74601c