### PR TITLE
Handle inline marketing markers without word boundaries

### DIFF
--- a/test/sanitizeTranscriptForPrompt.test.js
+++ b/test/sanitizeTranscriptForPrompt.test.js
@@ -55,3 +55,18 @@ test('sanitizeTranscriptForPrompt splits inline Glasp header markers', () => {
     `Expected sanitized transcript to start with "Daniel." but received: ${sanitized}`
   );
 });
+
+test('sanitizeTranscriptForPrompt splits markers following inline text', () => {
+  const rawTranscript = [
+    'Understanding AI in 2024 • Jan 5, 2024 • by Daniel Johnson #videogamessShare VideoDownload .srtCopyDaniel.',
+    'Daniel: Welcome back everyone.',
+    'Sarah: Thanks for having me!'
+  ].join('\n');
+
+  const sanitized = sanitizeTranscriptForPrompt(rawTranscript);
+
+  assert.ok(
+    sanitized.startsWith('Daniel.'),
+    `Expected sanitized transcript to start with "Daniel." but received: ${sanitized}`
+  );
+});


### PR DESCRIPTION
## Summary
- relax the Share, Download, and Copy marker detection to handle inline marketing headers
- preserve optional non-marker prefixes when inserting separator newlines around detected markers
- add a regression test covering the #videogamessShare marketing header sequence

## Testing
- node --test test/sanitizeTranscriptForPrompt.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d0dd5549208320bb8f1c68be234da1