### PR TITLE
Handle zero-width separators in transcript sanitization

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1276,14 +1276,21 @@ function sanitizeTranscriptForPrompt(transcript) {
     return '';
   }
 
+  const zeroWidthCharsRegex = /[\u200b\u200c\u200d\u2060\ufeff]/g;
+
   let normalizedText = transcript
     .replace(/\r\n?/g, '\n')
-    .replace(/[\u2028\u2029]/g, '\n');
+    .replace(/[\u2028\u2029]/g, '\n')
+    .replace(zeroWidthCharsRegex, '');
 
-  const shareMarkerCorePattern = 'Share\\s+Video(?=\\s|$|[.,;:?!]|[A-Z])';
+  const zeroWidthOptionalPattern = '[\\u200b\\u200c\\u200d\\u2060\\ufeff]*';
+  const markerBoundaryLookahead = `(?=${zeroWidthOptionalPattern}(?:\\s|$|[.,;:?!]|[A-Z]))`;
+  const markerContinuationLookahead = `(?=${zeroWidthOptionalPattern}(?:\\s|$|[.,;:?!]|Copy|Share|Download))`;
+
+  const shareMarkerCorePattern = `Share\\s+Video${markerBoundaryLookahead}`;
   const downloadMarkerCorePattern =
-    'Download\\s*(?:\\.[^\\s]+?(?=(?:\\s|$|[.,;:?!])|Copy|Share|Download)|[A-Za-z]+?(?=(?:\\s|$|[.,;:?!])|Copy|Share|Download))';
-  const copyMarkerCorePattern = 'Copy(?=\\s|$|[.,;:?!]|[A-Z])';
+    `Download\\s*(?:\\.[^\\s]+?${markerContinuationLookahead}|[A-Za-z]+?${markerContinuationLookahead})`;
+  const copyMarkerCorePattern = `Copy${markerBoundaryLookahead}`;
   const marketingMarkerPattern = `(?:${shareMarkerCorePattern}|${downloadMarkerCorePattern}|${copyMarkerCorePattern})`;
 
   const firstLineBreakIndex = normalizedText.indexOf('\n');

--- a/test/sanitizeTranscriptForPrompt.test.js
+++ b/test/sanitizeTranscriptForPrompt.test.js
@@ -70,3 +70,19 @@ test('sanitizeTranscriptForPrompt splits markers following inline text', () => {
     `Expected sanitized transcript to start with "Daniel." but received: ${sanitized}`
   );
 });
+
+test('sanitizeTranscriptForPrompt strips zero-width separator characters around markers', () => {
+  const zeroWidthSeparator = '\u2060';
+  const rawTranscript = [
+    `Understanding AI in 2024 • Jan 5, 2024 • by Daniel Johnson Share Video${zeroWidthSeparator}Download .srt${zeroWidthSeparator}Copy${zeroWidthSeparator}Daniel.`,
+    'Daniel: Welcome back everyone.',
+    'Sarah: Thanks for having me!'
+  ].join('\n');
+
+  const sanitized = sanitizeTranscriptForPrompt(rawTranscript);
+
+  assert.ok(
+    sanitized.startsWith('Daniel.'),
+    `Expected sanitized transcript to start with "Daniel." but received: ${sanitized}`
+  );
+});


### PR DESCRIPTION
## Summary
- strip zero-width formatting characters before scanning for Glasp marketing markers
- allow the marketing marker regex lookaheads to tolerate zero-width separators around tokens
- add a regression test that covers Glasp output with zero-width separators between markers

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68d0e2ee62b08320aaca7b7c18662884