### PR TITLE
Preserve zero-width characters in sanitized transcripts

### DIFF
--- a/test/sanitizeTranscriptForPrompt.test.js
+++ b/test/sanitizeTranscriptForPrompt.test.js
@@ -86,3 +86,22 @@ test('sanitizeTranscriptForPrompt strips zero-width separator characters around 
     `Expected sanitized transcript to start with "Daniel." but received: ${sanitized}`
   );
 });
+
+test('sanitizeTranscriptForPrompt preserves zero-width characters in body content', () => {
+  const zeroWidthNonJoiner = '\u200c';
+  const zeroWidthJoiner = '\u200d';
+  const bodyLineOne = `Exploring${zeroWidthNonJoiner}techniques for design`;
+  const bodyLineTwo = `Collaborative${zeroWidthJoiner}planning works well.`;
+  const rawTranscript = [
+    '& Summary',
+    'Share Video',
+    'Download .txt',
+    'Copy',
+    bodyLineOne,
+    bodyLineTwo
+  ].join('\n');
+
+  const sanitized = sanitizeTranscriptForPrompt(rawTranscript);
+
+  assert.strictEqual(sanitized, `${bodyLineOne}\n${bodyLineTwo}`);
+});


### PR DESCRIPTION
## Summary
- update `sanitizeTranscriptForPrompt` to stop stripping zero-width characters from the returned transcript while keeping marketing marker detection reliable
- adjust marker handling to tolerate zero-width separators and normalize comparison strings without mutating the final output
- add a regression test ensuring zero-width characters in body lines survive header trimming

## Testing
- node --test test/sanitizeTranscriptForPrompt.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d19111e2388320a7b956db35dd0b81