### PR TITLE
Refine transcript sanitizer header detection

### DIFF
--- a/test/sanitizeTranscriptForPrompt.test.js
+++ b/test/sanitizeTranscriptForPrompt.test.js
@@ -105,3 +105,14 @@ test('sanitizeTranscriptForPrompt preserves zero-width characters in body conten
 
   assert.strictEqual(sanitized, `${bodyLineOne}\n${bodyLineTwo}`);
 });
+
+test('sanitizeTranscriptForPrompt keeps regular sentences with marketing keywords intact', () => {
+  const rawTranscript = [
+    'Daniel: Download the dataset and copy the results later.',
+    'Sarah: Sounds good.'
+  ].join('\n');
+
+  const sanitized = sanitizeTranscriptForPrompt(rawTranscript);
+
+  assert.strictEqual(sanitized, rawTranscript);
+});


### PR DESCRIPTION
## Summary
- tighten sanitizeTranscriptForPrompt so it only trims text preceding marketing markers when the first line looks like a Glasp header
- avoid breaking sentences that include words such as “Download” by skipping marker isolation in those contexts
- add a regression test ensuring a normal first line mentioning downloads and copies remains unchanged

## Testing
- `node --test test/sanitizeTranscriptForPrompt.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d196687dd083209560d827cf46546b