### PR TITLE
Fix marker separator whitespace escaping

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1294,7 +1294,7 @@ function sanitizeTranscriptForPrompt(transcript) {
   const copyMarkerCorePattern = `Copy${markerBoundaryLookahead}`;
   const marketingMarkerPattern = `(?:${shareMarkerCorePattern}|${downloadMarkerCorePattern}|${copyMarkerCorePattern})`;
   const markerSeparatorCharacters =
-    `\\s\\u00a0${zeroWidthCharacters}&•*·\\-–—|/\\\\.,;:?!()\\[\\]"'`;
+    `\\\\s\\u00a0${zeroWidthCharacters}&•*·\\-–—|/\\\\.,;:?!()\\[\\]"'`;
   const markerSeparatorPattern = new RegExp(`^[${markerSeparatorCharacters}]*$`);
   const headerPrefixIndicatorKeywords = [
     'summary',


### PR DESCRIPTION
## Summary
- escape the whitespace class in `markerSeparatorCharacters` so separators can include spaces and tabs

## Testing
- `node --test test/sanitizeTranscriptForPrompt.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68d1abcd048483208adccf3c3727c3fa