### PR TITLE
Handle watch fallback wrappers when extracting player response

### DIFF
--- a/background.js
+++ b/background.js
@@ -697,12 +697,17 @@ function extractJsonObjectFromAssignment(source, marker) {
   const fallbackPattern = /^(?:window\[(?:"ytInitialPlayerResponse"|'ytInitialPlayerResponse')\]|window\.ytInitialPlayerResponse|ytInitialPlayerResponse)\s*\|\|/;
 
   while (cursor < source.length) {
-    while (cursor < source.length && /[\s=]+/.test(source[cursor])) {
+    while (cursor < source.length && /[\s=;]+/.test(source[cursor])) {
       cursor += 1;
     }
 
     if (cursor >= source.length) {
       return null;
+    }
+
+    if (source[cursor] === '(' || source[cursor] === ')') {
+      cursor += 1;
+      continue;
     }
 
     const remaining = source.slice(cursor);
@@ -712,7 +717,7 @@ function extractJsonObjectFromAssignment(source, marker) {
       continue;
     }
 
-    if (source.startsWith('JSON.parse', cursor)) {
+    if (remaining.startsWith('JSON.parse')) {
       const openParenIndex = source.indexOf('(', cursor);
       if (openParenIndex === -1) {
         cursor += 'JSON.parse'.length;

--- a/test/extractPlayerResponseFromWatchHtml.test.js
+++ b/test/extractPlayerResponseFromWatchHtml.test.js
@@ -1,5 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const noop = () => {};
 
@@ -39,6 +41,18 @@ test('extractPlayerResponseFromWatchHtml parses JSON after fallback expression',
 
   const result = extractPlayerResponseFromWatchHtml(html);
   assert.ok(result, 'Expected player response to be parsed');
+  assert.strictEqual(
+    result.captions.playerCaptionsTracklistRenderer.captionTracks[0].baseUrl,
+    'https://example.com/captions'
+  );
+});
+
+test('extractPlayerResponseFromWatchHtml parses JSON after window fallback in watch page fixture', () => {
+  const fixturePath = path.join(__dirname, 'fixtures/watch-with-fallback.html');
+  const html = fs.readFileSync(fixturePath, 'utf8');
+
+  const result = extractPlayerResponseFromWatchHtml(html);
+  assert.ok(result, 'Expected player response to be parsed from fixture');
   assert.strictEqual(
     result.captions.playerCaptionsTracklistRenderer.captionTracks[0].baseUrl,
     'https://example.com/captions'

--- a/test/fixtures/watch-with-fallback.html
+++ b/test/fixtures/watch-with-fallback.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script>
+      var ytInitialPlayerResponse = window.ytInitialPlayerResponse || {
+        "captions": {
+          "playerCaptionsTracklistRenderer": {
+            "captionTracks": [
+              {
+                "baseUrl": "https://example.com/captions"
+              }
+            ]
+          }
+        }
+      };
+    </script>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
## Summary
- skip common fallback wrappers when scanning for the start of ytInitialPlayerResponse assignments
- add a watch page fixture that assigns ytInitialPlayerResponse using window fallbacks and assert parsing succeeds

## Testing
- node test/extractPlayerResponseFromWatchHtml.test.js
- node test/sanitizeTranscriptForPrompt.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d48fcf7b608320ac2ef5e7e5c199be