### PR TITLE
Sanitize Glasp fallback metadata

### DIFF
--- a/background.js
+++ b/background.js
@@ -408,6 +408,98 @@ function isMarketingFooterLine(line) {
   return isStrongMarketingLine(line);
 }
 
+function stripLeadingGlaspMetadataLines(lines) {
+  if (!Array.isArray(lines)) {
+    return [];
+  }
+
+  const monthPattern =
+    /\b(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:t(?:ember)?)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\b/i;
+
+  const shouldDropLine = (line, metadataSeen) => {
+    if (typeof line !== 'string') {
+      return true;
+    }
+
+    const normalized = line.replace(/\u00a0/g, ' ').trim();
+    if (!normalized) {
+      return true;
+    }
+
+    if (/^#[\p{L}\p{N}_-]+/u.test(normalized)) {
+      return true;
+    }
+
+    if (monthPattern.test(normalized)) {
+      return true;
+    }
+
+    if (/^(?:\d{1,2}[\/-]){2}\d{2,4}$/.test(normalized)) {
+      return true;
+    }
+
+    if (/^\d{4}$/.test(normalized)) {
+      return true;
+    }
+
+    if (/^by\s*[:|]*$/i.test(normalized)) {
+      return true;
+    }
+
+    if (/^by\b/i.test(normalized)) {
+      const remainder = normalized.slice(2).trim();
+      if (!remainder) {
+        return true;
+      }
+
+      const firstWord = remainder.split(/\s+/)[0];
+      if (/^@[\w.-]+/.test(firstWord)) {
+        return true;
+      }
+
+      if (metadataSeen && (/^[A-Z#]/.test(firstWord) || /^[a-z]/.test(firstWord) === false)) {
+        return true;
+      }
+    }
+
+    if ((normalized.includes('#') || normalized.includes('@') || normalized.includes('•')) && metadataSeen) {
+      return true;
+    }
+
+    if (metadataSeen && /^[A-Z][\w'’.-]*(?:\s+[A-Z][\w'’.-]*)*$/.test(normalized)) {
+      return true;
+    }
+
+    return false;
+  };
+
+  let dropCount = 0;
+  let metadataSeen = false;
+  let dropNextAuthorLine = false;
+
+  for (const line of lines) {
+    if (dropNextAuthorLine) {
+      dropCount += 1;
+      metadataSeen = true;
+      dropNextAuthorLine = false;
+      continue;
+    }
+
+    if (!shouldDropLine(line, metadataSeen)) {
+      break;
+    }
+
+    const normalized = typeof line === 'string' ? line.replace(/\u00a0/g, ' ').trim() : '';
+    dropCount += 1;
+    metadataSeen = true;
+    if (/^by\s*[:|]*$/i.test(normalized)) {
+      dropNextAuthorLine = true;
+    }
+  }
+
+  return lines.slice(dropCount);
+}
+
 function parseTranscriptFromReaderText(pageText) {
   if (typeof pageText !== 'string' || pageText.trim().length === 0) {
     throw new Error('Empty response received from Glasp.');
@@ -436,16 +528,18 @@ function parseTranscriptFromReaderText(pageText) {
 
   const headerPattern = /^(?:Summarize\s+)?Transcript(?:\s*English\s*\(auto-generated\))?$/i;
 
-  const fallbackLines = transcriptSection
-    .split(/\n+/)
-    .map((line) => line.trim())
-    .filter(
-      (line) =>
-        line.length > 0 &&
-        !isMarketingFooterLine(line) &&
-        !headerPattern.test(line) &&
-        !/^English\s*\(auto-generated\)$/i.test(line)
-    );
+  const fallbackLines = stripLeadingGlaspMetadataLines(
+    transcriptSection
+      .split(/\n+/)
+      .map((line) => line.trim())
+      .filter(
+        (line) =>
+          line.length > 0 &&
+          !isMarketingFooterLine(line) &&
+          !headerPattern.test(line) &&
+          !/^English\s*\(auto-generated\)$/i.test(line)
+      )
+  );
 
   const fallbackTranscript = fallbackLines.join('\n').trim();
   if (!fallbackTranscript) {
@@ -1861,6 +1955,8 @@ async function injectPromptAndSend(prompt, autoSend = true, hasInjected = false)
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     extractPlayerResponseFromWatchHtml,
-    extractJsonObjectFromAssignment
+    extractJsonObjectFromAssignment,
+    parseTranscriptFromReaderText,
+    stripLeadingGlaspMetadataLines
   };
 }

--- a/test/parseTranscriptFromReaderText.test.js
+++ b/test/parseTranscriptFromReaderText.test.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+global.chrome = {
+  runtime: {
+    onMessage: { addListener: () => {} }
+  },
+  tabs: {
+    onUpdated: { addListener: () => {} },
+    onRemoved: { addListener: () => {} },
+    create: async () => ({ id: 1 }),
+    remove: async () => {},
+    get: async () => ({})
+  },
+  storage: {
+    session: {
+      get: async () => ({}),
+      set: async () => {},
+      remove: async () => {}
+    }
+  }
+};
+
+const { parseTranscriptFromReaderText } = require('../background.js');
+
+test('parseTranscriptFromReaderText strips leading Glasp metadata headers', () => {
+  const pageText = [
+    'Transcript',
+    '#philosophaire',
+    '#stoicism',
+    'May 5, 2024',
+    'by',
+    'Philosophaire',
+    'Host: Welcome back to the show.',
+    'Guest: Thanks for inviting me.'
+  ].join('\n');
+
+  const transcript = parseTranscriptFromReaderText(pageText);
+
+  assert.ok(
+    transcript.startsWith('Host: Welcome back to the show.'),
+    `Expected transcript to start with spoken text, received: ${transcript}`
+  );
+  assert.ok(!/philosophaire/i.test(transcript));
+  assert.ok(!/May 5, 2024/.test(transcript));
+});


### PR DESCRIPTION
## Summary
- add a metadata stripping helper to clean fallback Glasp transcripts
- apply the helper inside parseTranscriptFromReaderText so spoken lines lead the transcript
- cover the #philosophaire header block with a new regression test

## Testing
- node test/parseTranscriptFromReaderText.test.js
- node test/sanitizeTranscriptForPrompt.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d4912b596c8320aee54e422f1f6018