### PR TITLE
Fix Glasp transcript metadata stripping and player response parsing

### DIFF
--- a/background.js
+++ b/background.js
@@ -156,6 +156,15 @@ async function fetchTranscriptFromGlasp(videoUrl) {
   }
 }
 
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    parseTranscriptFromReaderText,
+    stripLeadingGlaspMetadataLines,
+    extractPlayerResponseFromWatchHtml,
+    extractJsonObjectFromAssignment
+  };
+}
+
 async function openChatGPTTab(prompt, preferredHost, autoSend) {
   if (typeof prompt !== 'string' || !prompt.trim()) {
     throw new Error('Invalid prompt supplied.');
@@ -447,12 +456,126 @@ function parseTranscriptFromReaderText(pageText) {
         !/^English\s*\(auto-generated\)$/i.test(line)
     );
 
-  const fallbackTranscript = fallbackLines.join('\n').trim();
+  const strippedFallbackLines = stripLeadingGlaspMetadataLines(fallbackLines);
+  const fallbackTranscript = strippedFallbackLines.join('\n').trim();
   if (!fallbackTranscript) {
     throw new Error('Transcript data not found on Glasp for this video.');
   }
 
   return fallbackTranscript;
+}
+
+function stripLeadingGlaspMetadataLines(lines) {
+  if (!Array.isArray(lines)) {
+    return [];
+  }
+
+  const metadataKeywords = [
+    'youtube transcript & summary',
+    '& summary',
+    'summary',
+    'transcripts',
+    'youtube video player',
+    'share video',
+    'download .srt',
+    'copy transcript',
+    'copy',
+    'summarize transcript',
+    'get transcript & summary'
+  ];
+
+  const keywordSet = new Set(metadataKeywords.map((value) => value.toLowerCase()));
+  const combinedKeywordPatterns = metadataKeywords.map((keyword) => {
+    const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(escaped.replace(/\s+/g, '\\s*'), 'i');
+  });
+
+  const monthNames = [
+    'january',
+    'february',
+    'march',
+    'april',
+    'may',
+    'june',
+    'july',
+    'august',
+    'september',
+    'october',
+    'november',
+    'december'
+  ];
+
+  const datePattern = new RegExp(
+    `^(?:${monthNames.join('|')})\\s+\\d{1,2},\\s*\\d{4}$`,
+    'i'
+  );
+
+  let index = 0;
+  let removedAny = false;
+  let skipNext = false;
+
+  while (index < lines.length) {
+    if (skipNext) {
+      skipNext = false;
+      removedAny = true;
+      index += 1;
+      continue;
+    }
+
+    const current = lines[index];
+    const trimmed = typeof current === 'string' ? current.trim() : '';
+    if (!trimmed) {
+      removedAny = true;
+      index += 1;
+      continue;
+    }
+
+    const lower = trimmed.toLowerCase();
+
+    if (/^#\S+/.test(trimmed)) {
+      removedAny = true;
+      index += 1;
+      continue;
+    }
+
+    if (keywordSet.has(lower) || combinedKeywordPatterns.some((pattern) => pattern.test(trimmed))) {
+      removedAny = true;
+      index += 1;
+      continue;
+    }
+
+    if (lower === 'by') {
+      skipNext = true;
+      index += 1;
+      continue;
+    }
+
+    if (lower.startsWith('by ')) {
+      removedAny = true;
+      index += 1;
+      continue;
+    }
+
+    const nextLine = typeof lines[index + 1] === 'string' ? lines[index + 1].trim() : '';
+    if (
+      datePattern.test(trimmed) &&
+      (removedAny || /^(?:by\b|#|share\b|download\b|copy\b|summarize\b)/i.test(nextLine))
+    ) {
+      removedAny = true;
+      index += 1;
+      continue;
+    }
+
+    if (trimmed === 's' && removedAny) {
+      removedAny = true;
+      index += 1;
+      continue;
+    }
+
+    break;
+  }
+
+  return lines.slice(index);
 }
 
 function truncateMarketingContent(text) {
@@ -582,6 +705,15 @@ async function fetchTranscriptFromYouTube(videoUrl) {
     throw new Error('Unable to determine video ID for transcript fallback.');
   }
 
+  try {
+    const transcriptFromWatchPage = await fetchTranscriptFromWatchPage(videoId);
+    if (transcriptFromWatchPage) {
+      return transcriptFromWatchPage;
+    }
+  } catch (error) {
+    console.debug('Failed to fetch transcript from watch page', error);
+  }
+
   const paramVariants = ['lang=en&fmt=json3', 'lang=en&kind=asr&fmt=json3', 'lang=en-US&fmt=json3', 'lang=en-US&kind=asr&fmt=json3'];
 
   for (const params of paramVariants) {
@@ -603,6 +735,482 @@ async function fetchTranscriptFromYouTube(videoUrl) {
   }
 
   throw new Error('Timed YouTube transcript unavailable.');
+}
+
+async function fetchTranscriptFromWatchPage(videoId) {
+  const watchUrl = buildWatchPageUrl(videoId);
+  if (!watchUrl) {
+    throw new Error('Unable to resolve watch page URL for transcript retrieval.');
+  }
+
+  const response = await fetch(watchUrl, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`Watch page request failed with status ${response.status}`);
+  }
+
+  const html = await response.text();
+  const playerResponse = extractPlayerResponseFromWatchHtml(html);
+  if (!playerResponse) {
+    throw new Error('Unable to locate player response in watch page HTML.');
+  }
+
+  const captionTrack = selectBestCaptionTrack(playerResponse);
+  if (!captionTrack || typeof captionTrack.baseUrl !== 'string') {
+    throw new Error('No caption track with a valid base URL was found in the player response.');
+  }
+
+  const requestUrl = buildTimedTextRequestUrl(captionTrack.baseUrl);
+  if (!requestUrl) {
+    throw new Error('Unable to normalize the caption track URL for transcript retrieval.');
+  }
+
+  const timedTextData = await fetchTimedTextJson(requestUrl);
+  if (!timedTextData) {
+    throw new Error('Timed text response from YouTube was empty.');
+  }
+
+  const formatted = parseTimedTextJson(timedTextData);
+  if (!formatted) {
+    throw new Error('Unable to format timed text transcript from YouTube watch page.');
+  }
+
+  return formatted;
+}
+
+function buildWatchPageUrl(videoId) {
+  if (!videoId) {
+    return null;
+  }
+
+  return `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`;
+}
+
+function extractPlayerResponseFromWatchHtml(html) {
+  if (typeof html !== 'string' || !html) {
+    return null;
+  }
+
+  const assignmentMarkers = ['ytInitialPlayerResponse =', 'window["ytInitialPlayerResponse"] ='];
+  for (const marker of assignmentMarkers) {
+    const parsed = extractJsonObjectFromAssignment(html, marker);
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  const inlineMatch = html.match(/"playerResponse":\s*(\{.*?\})\s*,\s*"responseContext"/s);
+  if (inlineMatch) {
+    try {
+      return JSON.parse(inlineMatch[1]);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function extractJsonObjectFromAssignment(source, marker) {
+  const index = source.indexOf(marker);
+  if (index === -1) {
+    return null;
+  }
+
+  let cursor = index + marker.length;
+
+  while (cursor < source.length) {
+    const current = source[cursor];
+
+    if (/\s/.test(current) || current === '=') {
+      cursor += 1;
+      continue;
+    }
+
+    if (current === '(' || current === '!' || current === ')') {
+      cursor += 1;
+      continue;
+    }
+
+    if (current === '{') {
+      const jsonText = extractBalancedJson(source, cursor);
+      if (!jsonText) {
+        return null;
+      }
+      try {
+        return JSON.parse(jsonText);
+      } catch (error) {
+        return null;
+      }
+    }
+
+    if (current === '"' || current === '\'') {
+      const literal = extractJsStringLiteral(source, cursor);
+      if (!literal) {
+        return null;
+      }
+      const decoded = decodeJsStringLiteral(literal);
+      if (decoded === null) {
+        return null;
+      }
+      try {
+        return JSON.parse(decoded);
+      } catch (error) {
+        return null;
+      }
+    }
+
+    if (source.startsWith('JSON.parse', cursor)) {
+      const openParenIndex = source.indexOf('(', cursor);
+      if (openParenIndex === -1) {
+        return null;
+      }
+
+      let argumentIndex = openParenIndex + 1;
+      while (argumentIndex < source.length && /\s/.test(source[argumentIndex])) {
+        argumentIndex += 1;
+      }
+
+      if (argumentIndex >= source.length) {
+        return null;
+      }
+
+      const argumentStart = source[argumentIndex];
+      if (argumentStart === '"' || argumentStart === '\'') {
+        const literal = extractJsStringLiteral(source, argumentIndex);
+        if (!literal) {
+          return null;
+        }
+        const decoded = decodeJsStringLiteral(literal);
+        if (decoded === null) {
+          return null;
+        }
+        try {
+          return JSON.parse(decoded);
+        } catch (error) {
+          return null;
+        }
+      }
+    }
+
+    if (/[A-Za-z0-9_$.[\]]/.test(current)) {
+      cursor = advancePastIdentifierChain(source, cursor);
+      continue;
+    }
+
+    if (current === '|' || current === '&' || current === '?' || current === ':' || current === '+') {
+      cursor += 1;
+      continue;
+    }
+
+    cursor += 1;
+  }
+
+  return null;
+}
+
+function advancePastIdentifierChain(source, startIndex) {
+  let cursor = startIndex;
+  while (cursor < source.length) {
+    const character = source[cursor];
+    if (/[A-Za-z0-9_$]/.test(character)) {
+      cursor += 1;
+      continue;
+    }
+
+    if (character === '.') {
+      cursor += 1;
+      continue;
+    }
+
+    if (character === '[') {
+      cursor += 1;
+      while (cursor < source.length && /\s/.test(source[cursor])) {
+        cursor += 1;
+      }
+
+      if (cursor >= source.length) {
+        return cursor;
+      }
+
+      const bracketStart = source[cursor];
+      if (bracketStart === '"' || bracketStart === '\'') {
+        const literal = extractJsStringLiteral(source, cursor);
+        if (!literal) {
+          return cursor;
+        }
+        cursor += literal.length;
+        while (cursor < source.length && /\s/.test(source[cursor])) {
+          cursor += 1;
+        }
+        if (source[cursor] === ']') {
+          cursor += 1;
+          continue;
+        }
+        return cursor;
+      }
+
+      while (cursor < source.length && source[cursor] !== ']') {
+        cursor += 1;
+      }
+      if (source[cursor] === ']') {
+        cursor += 1;
+      }
+      continue;
+    }
+
+    if (character === ']') {
+      cursor += 1;
+      continue;
+    }
+
+    break;
+  }
+
+  return cursor;
+}
+
+function extractBalancedJson(source, startIndex) {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = startIndex; index < source.length; index += 1) {
+    const character = source[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (character === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) {
+      continue;
+    }
+
+    if (character === '{') {
+      depth += 1;
+    } else if (character === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(startIndex, index + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+function extractJsStringLiteral(source, startIndex) {
+  const quote = source[startIndex];
+  let cursor = startIndex + 1;
+  let escaped = false;
+
+  while (cursor < source.length) {
+    const character = source[cursor];
+    if (escaped) {
+      escaped = false;
+    } else if (character === '\\') {
+      escaped = true;
+    } else if (character === quote) {
+      return source.slice(startIndex, cursor + 1);
+    }
+    cursor += 1;
+  }
+
+  return null;
+}
+
+function decodeJsStringLiteral(literal) {
+  if (typeof literal !== 'string' || literal.length < 2) {
+    return null;
+  }
+
+  const quote = literal[0];
+  if ((quote !== '"' && quote !== '\'') || literal[literal.length - 1] !== quote) {
+    return null;
+  }
+
+  let result = '';
+  for (let index = 1; index < literal.length - 1; index += 1) {
+    const character = literal[index];
+    if (character === '\\') {
+      index += 1;
+      if (index >= literal.length - 1) {
+        break;
+      }
+
+      const next = literal[index];
+      switch (next) {
+        case 'n':
+          result += '\n';
+          break;
+        case 'r':
+          result += '\r';
+          break;
+        case 't':
+          result += '\t';
+          break;
+        case 'b':
+          result += '\b';
+          break;
+        case 'f':
+          result += '\f';
+          break;
+        case 'v':
+          result += '\v';
+          break;
+        case '0':
+          result += '\0';
+          break;
+        case '\\':
+          result += '\\';
+          break;
+        case '\'':
+          result += '\'';
+          break;
+        case '"':
+          result += '"';
+          break;
+        case 'x': {
+          const hex = literal.slice(index + 1, index + 3);
+          if (/^[0-9A-Fa-f]{2}$/.test(hex)) {
+            result += String.fromCharCode(Number.parseInt(hex, 16));
+            index += 2;
+          } else {
+            result += next;
+          }
+          break;
+        }
+        case 'u': {
+          const hex = literal.slice(index + 1, index + 5);
+          if (/^[0-9A-Fa-f]{4}$/.test(hex)) {
+            result += String.fromCharCode(Number.parseInt(hex, 16));
+            index += 4;
+          } else {
+            result += next;
+          }
+          break;
+        }
+        default:
+          result += next;
+          break;
+      }
+    } else {
+      result += character;
+    }
+  }
+
+  return result;
+}
+
+function selectBestCaptionTrack(playerResponse) {
+  const tracks = playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+  if (!Array.isArray(tracks) || tracks.length === 0) {
+    return null;
+  }
+
+  const viableTracks = tracks.filter((track) => track && typeof track.baseUrl === 'string' && track.baseUrl.trim().length > 0);
+  if (viableTracks.length === 0) {
+    return null;
+  }
+
+  const scored = viableTracks
+    .map((track, index) => ({ track, index, score: scoreCaptionTrack(track) }))
+    .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      return a.index - b.index;
+    });
+
+  return scored[0]?.track ?? null;
+}
+
+function scoreCaptionTrack(track) {
+  if (!track || typeof track !== 'object') {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  let score = 0;
+  const languageCode = typeof track.languageCode === 'string' ? track.languageCode.toLowerCase() : '';
+  const vssId = typeof track.vssId === 'string' ? track.vssId.toLowerCase() : '';
+  const trackKind = typeof track.kind === 'string' ? track.kind.toLowerCase() : '';
+
+  if (languageCode === 'en') {
+    score += 30;
+  } else if (languageCode.startsWith('en')) {
+    score += 25;
+  } else if (languageCode) {
+    score += 10;
+  }
+
+  if (!trackKind) {
+    score += 5;
+  } else if (trackKind === 'asr') {
+    score -= 5;
+  }
+
+  if (vssId.startsWith('a.')) {
+    score -= 2;
+  }
+
+  if (track.isTranslatable) {
+    score += 1;
+  }
+
+  return score;
+}
+
+function buildTimedTextRequestUrl(baseUrl) {
+  if (typeof baseUrl !== 'string' || !baseUrl.trim()) {
+    return null;
+  }
+
+  try {
+    const url = new URL(baseUrl);
+    url.searchParams.set('fmt', 'json3');
+    return url.toString();
+  } catch (error) {
+    return null;
+  }
+}
+
+async function fetchTimedTextJson(requestUrl) {
+  if (typeof requestUrl !== 'string' || !requestUrl) {
+    return null;
+  }
+
+  const response = await fetch(requestUrl, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`Timed text request failed with status ${response.status}`);
+  }
+
+  const rawText = await response.text();
+  const sanitized = stripXssiPrefix(rawText).trim();
+  if (!sanitized) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(sanitized);
+  } catch (error) {
+    throw new Error('Unable to parse timed text response as JSON.');
+  }
+}
+
+function stripXssiPrefix(text) {
+  if (typeof text !== 'string') {
+    return '';
+  }
+  return text.replace(/^\)\]\}'\s*/u, '');
 }
 
 function extractVideoIdFromUrl(videoUrl) {

--- a/test/extractPlayerResponseFromWatchHtml.test.js
+++ b/test/extractPlayerResponseFromWatchHtml.test.js
@@ -1,0 +1,57 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function createChromeStub() {
+  return {
+    runtime: { onMessage: { addListener: () => {} } },
+    tabs: {
+      onUpdated: { addListener: () => {}, removeListener: () => {} },
+      onRemoved: { addListener: () => {}, removeListener: () => {} },
+      create: async () => ({}),
+      remove: async () => {},
+      get: async () => ({})
+    },
+    storage: {
+      session: {
+        async get() {
+          return {};
+        },
+        async set() {},
+        async remove() {}
+      },
+      local: {
+        async get() {
+          return {};
+        },
+        async set() {},
+        async remove() {}
+      }
+    },
+    scripting: {
+      async executeScript() {
+        return [{ result: '' }];
+      }
+    }
+  };
+}
+
+if (typeof global.chrome === 'undefined') {
+  global.chrome = createChromeStub();
+}
+
+const { extractPlayerResponseFromWatchHtml } = require('../background.js');
+
+test('extractPlayerResponseFromWatchHtml parses assignments with fallback expressions', () => {
+  const fixturePath = path.join(__dirname, 'fixtures', 'watch-with-fallback.html');
+  const html = fs.readFileSync(fixturePath, 'utf8');
+
+  const playerResponse = extractPlayerResponseFromWatchHtml(html);
+
+  assert.ok(playerResponse, 'Expected a player response object');
+  assert.deepStrictEqual(
+    playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks?.[0]?.baseUrl,
+    'https://example.com/captions'
+  );
+});

--- a/test/fixtures/watch-with-fallback.html
+++ b/test/fixtures/watch-with-fallback.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YouTube</title>
+  </head>
+  <body>
+    <script>
+      var ytInitialPlayerResponse = window.ytInitialPlayerResponse || {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://example.com/captions"}]}}};
+    </script>
+  </body>
+</html>

--- a/test/parseTranscriptFromReaderText.test.js
+++ b/test/parseTranscriptFromReaderText.test.js
@@ -1,0 +1,109 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function createChromeStub() {
+  return {
+    runtime: { onMessage: { addListener: () => {} } },
+    tabs: {
+      onUpdated: { addListener: () => {}, removeListener: () => {} },
+      onRemoved: { addListener: () => {}, removeListener: () => {} },
+      create: async () => ({}),
+      remove: async () => {},
+      get: async () => ({})
+    },
+    storage: {
+      session: {
+        async get() {
+          return {};
+        },
+        async set() {},
+        async remove() {}
+      },
+      local: {
+        async get() {
+          return {};
+        },
+        async set() {},
+        async remove() {}
+      }
+    },
+    scripting: {
+      async executeScript() {
+        return [{ result: '' }];
+      }
+    }
+  };
+}
+
+if (typeof global.chrome === 'undefined') {
+  global.chrome = createChromeStub();
+}
+
+const {
+  parseTranscriptFromReaderText,
+  stripLeadingGlaspMetadataLines
+} = require('../background.js');
+
+test('stripLeadingGlaspMetadataLines removes Glasp header metadata', () => {
+  const lines = [
+    '#philosophaire',
+    'September 18, 2025',
+    'by',
+    'Philosophaire',
+    '#philosophaires',
+    'Share Video',
+    'Download .srt',
+    'Copy',
+    'As you get older, you start seeing things differently.'
+  ];
+
+  const stripped = stripLeadingGlaspMetadataLines(lines);
+
+  assert.deepStrictEqual(stripped, [
+    'As you get older, you start seeing things differently.'
+  ]);
+});
+
+test('parseTranscriptFromReaderText drops Glasp metadata headers', () => {
+  const pageText = [
+    'Glasp Reader',
+    'YouTube Transcript & Summary',
+    '#philosophaire',
+    'September 18, 2025',
+    'by',
+    'Philosophaire',
+    'YouTube video player',
+    '#philosophaires',
+    'Transcripts',
+    'Share Video',
+    'Download .srt',
+    'Copy Transcript',
+    'Summarize Transcript',
+    'English (auto-generated)',
+    'As you get older, you start seeing things differently.',
+    'You notice how people affect your peace.'
+  ].join('\n');
+
+  const parsed = parseTranscriptFromReaderText(pageText);
+
+  assert.strictEqual(
+    parsed,
+    [
+      'As you get older, you start seeing things differently.',
+      'You notice how people affect your peace.'
+    ].join('\n')
+  );
+});
+
+test('stripLeadingGlaspMetadataLines removes glued metadata tokens', () => {
+  const lines = [
+    '#creatorShare VideoDownload .srtCopy',
+    'September 19, 2025',
+    'by Creator Name',
+    'Opening line of the transcript.'
+  ];
+
+  const stripped = stripLeadingGlaspMetadataLines(lines);
+
+  assert.deepStrictEqual(stripped, ['Opening line of the transcript.']);
+});


### PR DESCRIPTION
## Summary
- strip leading Glasp header metadata before assembling fallback transcripts from the reader page
- expose helpers for testing and add unit coverage for stripping metadata and parsing watch pages with fallback assignments
- make the ytInitialPlayerResponse parser skip wrapper expressions while scanning for JSON payloads

## Testing
- node test/parseTranscriptFromReaderText.test.js
- node test/extractPlayerResponseFromWatchHtml.test.js
- node test/sanitizeTranscriptForPrompt.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d2f8d0092883209e74c5edb9e47fd3