### PR TITLE
Improve Glasp metadata stripping for fused title headers

### DIFF
--- a/background.js
+++ b/background.js
@@ -156,6 +156,17 @@ async function fetchTranscriptFromGlasp(videoUrl) {
   }
 }
 
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    parseTranscriptFromReaderText,
+    stripLeadingGlaspMetadataLines,
+    extractPlayerResponseFromWatchHtml,
+    extractJsonObjectFromAssignment,
+    isConsentInterstitialHtml,
+    buildWatchPageUrl
+  };
+}
+
 async function openChatGPTTab(prompt, preferredHost, autoSend) {
   if (typeof prompt !== 'string' || !prompt.trim()) {
     throw new Error('Invalid prompt supplied.');
@@ -447,12 +458,225 @@ function parseTranscriptFromReaderText(pageText) {
         !/^English\s*\(auto-generated\)$/i.test(line)
     );
 
-  const fallbackTranscript = fallbackLines.join('\n').trim();
+  const strippedFallbackLines = stripLeadingGlaspMetadataLines(fallbackLines);
+  const fallbackTranscript = strippedFallbackLines.join('\n').trim();
   if (!fallbackTranscript) {
     throw new Error('Transcript data not found on Glasp for this video.');
   }
 
   return fallbackTranscript;
+}
+
+function stripLeadingGlaspMetadataLines(lines) {
+  if (!Array.isArray(lines)) {
+    return [];
+  }
+
+  const cleaned = [];
+  let skipping = true;
+  let skipNext = false;
+  let removedAny = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (skipNext) {
+      skipNext = false;
+      removedAny = true;
+      continue;
+    }
+
+    const current = lines[index];
+    const trimmed = typeof current === 'string' ? current.trim() : '';
+
+    if (!trimmed) {
+      if (skipping) {
+        removedAny = true;
+        continue;
+      }
+      cleaned.push(trimmed);
+      continue;
+    }
+
+    if (!skipping) {
+      cleaned.push(trimmed);
+      continue;
+    }
+
+    const processed = stripGlaspMetadataPrefix(trimmed, removedAny);
+    if (processed.skipNextLine) {
+      skipNext = true;
+    }
+
+    if (processed.text) {
+      cleaned.push(processed.text);
+      skipping = false;
+    } else if (!processed.removed) {
+      cleaned.push(trimmed);
+      skipping = false;
+    }
+
+    if (processed.removed) {
+      removedAny = true;
+    }
+  }
+
+  return cleaned;
+}
+
+function stripGlaspMetadataPrefix(line, hasRemovedEarlier) {
+  if (typeof line !== 'string') {
+    return { text: '', removed: false, skipNextLine: false };
+  }
+
+  const monthNames = [
+    'january',
+    'february',
+    'march',
+    'april',
+    'may',
+    'june',
+    'july',
+    'august',
+    'september',
+    'october',
+    'november',
+    'december'
+  ];
+
+  const datePattern = new RegExp(
+    `^(?:${monthNames.join('|')})\\s+\\d{1,2},\\s*\\d{4}`,
+    'i'
+  );
+
+  const tokenPatterns = [
+    /^glasp\s*reader/i,
+    /^youtube\s*transcript\s*&\s*summary/i,
+    /^&\s*summary/i,
+    /^youtube\s*video\s*player/i,
+    /^transcripts?/i,
+    /^share\s*video/i,
+    /^download\s*\.?srt/i,
+    /^copy(?:\s*transcript)?/i,
+    /^summarize\s*transcript/i,
+    /^english\s*\(auto-generated\)/i,
+    /^share\s*this\s*page/i,
+    /^get\s*(?:youtube\s*)?video\s*transcript\s*&\s*summary/i,
+    /^get\s*transcript\s*&\s*summary/i
+  ];
+
+  let working = line.trimStart();
+  let removedAny = false;
+  let skipNextLine = false;
+
+  for (let iteration = 0; iteration < 50; iteration += 1) {
+    if (!working) {
+      break;
+    }
+
+    let matched = false;
+
+    const hashtagMatch = working.match(/^#[^\s#]+/);
+    if (hashtagMatch) {
+      working = working.slice(hashtagMatch[0].length).trimStart();
+      removedAny = true;
+      matched = true;
+    }
+
+    if (!matched) {
+      const dateMatch = working.match(datePattern);
+      if (dateMatch) {
+        working = working.slice(dateMatch[0].length).trimStart();
+        removedAny = true;
+        matched = true;
+      }
+    }
+
+    if (!matched) {
+      const numericDateMatch = working.match(/^\d{1,2},\s*\d{4}/);
+      if (numericDateMatch) {
+        working = working.slice(numericDateMatch[0].length).trimStart();
+        removedAny = true;
+        matched = true;
+      }
+    }
+
+    if (!matched) {
+      for (const pattern of tokenPatterns) {
+        const tokenMatch = working.match(pattern);
+        if (tokenMatch) {
+          working = working.slice(tokenMatch[0].length).trimStart();
+          removedAny = true;
+          matched = true;
+          break;
+        }
+      }
+    }
+
+    if (!matched) {
+      const fusedControlMatch = working.match(
+        /(?:share\s*video|download\s*\.?srt|copy(?:\s*transcript)?|summarize\s*transcript)/i
+      );
+      if (fusedControlMatch && fusedControlMatch.index !== undefined && fusedControlMatch.index < 200) {
+        const sliceIndex = fusedControlMatch.index + fusedControlMatch[0].length;
+        const remainder = working.slice(sliceIndex).trimStart();
+        if (remainder) {
+          working = remainder;
+          removedAny = true;
+          matched = true;
+        }
+      }
+    }
+
+    if (!matched) {
+      const byMatch = working.match(/^by(?:\b|\s+|(?=[A-Z#]))/i);
+      if (byMatch) {
+        working = working.slice(byMatch[0].length);
+        working = working.trimStart();
+        removedAny = true;
+        matched = true;
+
+        const nameMatch = working.match(/^[A-Z][A-Za-z0-9'._-]*(?:\s+[A-Za-z0-9'._-]+)*/);
+        if (nameMatch) {
+          working = working.slice(nameMatch[0].length);
+        } else {
+          skipNextLine = true;
+        }
+
+        working = working.trimStart();
+      }
+    }
+
+    if (!matched && removedAny) {
+      const videoMatch = working.match(/^video/i);
+      if (videoMatch) {
+        const remainder = working.slice(videoMatch[0].length).trimStart();
+        if (/^download/i.test(remainder)) {
+          working = remainder;
+          matched = true;
+        }
+      }
+    }
+
+    if (!matched && /^s$/i.test(working)) {
+      working = '';
+      removedAny = true;
+      matched = true;
+    }
+
+    if (!matched && removedAny && working && (working[0] === 's' || working[0] === 'S')) {
+      working = working.slice(1).trimStart();
+      matched = true;
+    }
+
+    if (!matched) {
+      break;
+    }
+  }
+
+  return {
+    text: working.trimStart(),
+    removed: removedAny,
+    skipNextLine
+  };
 }
 
 function truncateMarketingContent(text) {
@@ -582,6 +806,15 @@ async function fetchTranscriptFromYouTube(videoUrl) {
     throw new Error('Unable to determine video ID for transcript fallback.');
   }
 
+  try {
+    const transcriptFromWatchPage = await fetchTranscriptFromWatchPage(videoId);
+    if (transcriptFromWatchPage) {
+      return transcriptFromWatchPage;
+    }
+  } catch (error) {
+    console.debug('Failed to fetch transcript from watch page', error);
+  }
+
   const paramVariants = ['lang=en&fmt=json3', 'lang=en&kind=asr&fmt=json3', 'lang=en-US&fmt=json3', 'lang=en-US&kind=asr&fmt=json3'];
 
   for (const params of paramVariants) {
@@ -603,6 +836,591 @@ async function fetchTranscriptFromYouTube(videoUrl) {
   }
 
   throw new Error('Timed YouTube transcript unavailable.');
+}
+
+async function fetchTranscriptFromWatchPage(videoId) {
+  const watchUrlCandidates = Array.from(
+    new Set(
+      [
+        buildWatchPageUrl(videoId),
+        buildWatchPageUrl(videoId, {
+          app: 'desktop',
+          persist_app: '1',
+          has_verified: '1',
+          hl: 'en',
+          gl: 'US',
+          persist_hl: '1',
+          persist_gl: '1',
+          bpctr: String(Math.max(1, Math.floor(Date.now() / 1000)))
+        })
+      ].filter(Boolean)
+    )
+  );
+
+  let lastError = null;
+  let playerResponse = null;
+
+  for (const watchUrl of watchUrlCandidates) {
+    if (!watchUrl) {
+      continue;
+    }
+
+    let response;
+    try {
+      response = await fetch(watchUrl, { credentials: 'include', redirect: 'follow' });
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error('Watch page request failed.');
+      continue;
+    }
+
+    if (!response.ok) {
+      lastError = new Error(`Watch page request failed with status ${response.status}`);
+      continue;
+    }
+
+    const html = await response.text();
+    if (isConsentInterstitialHtml(html)) {
+      lastError = new Error('Watch page request returned a consent interstitial.');
+      continue;
+    }
+
+    const parsed = extractPlayerResponseFromWatchHtml(html);
+    if (!parsed) {
+      lastError = new Error('Unable to locate player response in watch page HTML.');
+      continue;
+    }
+
+    playerResponse = parsed;
+    break;
+  }
+
+  if (!playerResponse) {
+    throw lastError || new Error('Unable to locate player response in watch page HTML.');
+  }
+
+  const captionTrack = selectBestCaptionTrack(playerResponse);
+  if (!captionTrack || typeof captionTrack.baseUrl !== 'string') {
+    throw new Error('No caption track with a valid base URL was found in the player response.');
+  }
+
+  const requestUrl = buildTimedTextRequestUrl(captionTrack.baseUrl);
+  if (!requestUrl) {
+    throw new Error('Unable to normalize the caption track URL for transcript retrieval.');
+  }
+
+  const timedTextData = await fetchTimedTextJson(requestUrl);
+  if (!timedTextData) {
+    throw new Error('Timed text response from YouTube was empty.');
+  }
+
+  const formatted = parseTimedTextJson(timedTextData);
+  if (!formatted) {
+    throw new Error('Unable to format timed text transcript from YouTube watch page.');
+  }
+
+  return formatted;
+}
+
+function buildWatchPageUrl(videoId, queryOverrides = null, baseUrl = 'https://www.youtube.com/watch') {
+  if (!videoId) {
+    return null;
+  }
+
+  try {
+    const url = new URL(baseUrl);
+    url.searchParams.set('v', videoId);
+
+    if (queryOverrides && typeof queryOverrides === 'object') {
+      for (const [key, value] of Object.entries(queryOverrides)) {
+        if (value === undefined || value === null) {
+          continue;
+        }
+        url.searchParams.set(key, String(value));
+      }
+    }
+
+    return url.toString();
+  } catch (error) {
+    return null;
+  }
+}
+
+function extractPlayerResponseFromWatchHtml(html) {
+  if (typeof html !== 'string' || !html) {
+    return null;
+  }
+
+  const assignmentMarkers = [
+    'ytInitialPlayerResponse =',
+    'var ytInitialPlayerResponse =',
+    'let ytInitialPlayerResponse =',
+    'const ytInitialPlayerResponse =',
+    'window["ytInitialPlayerResponse"] =',
+    'window.ytInitialPlayerResponse =',
+    'self.ytInitialPlayerResponse =',
+    'this.ytInitialPlayerResponse ='
+  ];
+  for (const marker of assignmentMarkers) {
+    const parsed = extractJsonObjectFromAssignment(html, marker);
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  const inlineMatch = html.match(/"playerResponse":\s*(\{.*?\})\s*,\s*"responseContext"/s);
+  if (inlineMatch) {
+    try {
+      return JSON.parse(inlineMatch[1]);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function isConsentInterstitialHtml(html) {
+  if (typeof html !== 'string' || !html) {
+    return false;
+  }
+
+  const lower = html.slice(0, 50000).toLowerCase();
+  if (!lower.includes('consent.youtube.com') && !lower.includes('consent.google.com')) {
+    return false;
+  }
+
+  if (lower.includes('before you continue to youtube')) {
+    return true;
+  }
+
+  if (/<form[^>]+action="https:\/\/consent\.youtube\.com\//i.test(html)) {
+    return true;
+  }
+
+  return false;
+}
+
+function extractJsonObjectFromAssignment(source, marker) {
+  if (typeof source !== 'string' || !marker) {
+    return null;
+  }
+
+  let searchIndex = 0;
+
+  while (searchIndex < source.length) {
+    const index = source.indexOf(marker, searchIndex);
+    if (index === -1) {
+      break;
+    }
+
+    let cursor = index + marker.length;
+
+    while (cursor < source.length) {
+      const current = source[cursor];
+
+      if (/\s/.test(current) || current === '=') {
+        cursor += 1;
+        continue;
+    }
+
+    if (current === '(' || current === '!' || current === ')') {
+      cursor += 1;
+      continue;
+    }
+
+      if (current === '{') {
+        const jsonText = extractBalancedJson(source, cursor);
+        if (jsonText) {
+          try {
+            return JSON.parse(jsonText);
+          } catch (error) {
+            // continue scanning for other payloads
+          }
+        }
+        cursor += 1;
+        continue;
+      }
+
+      if (current === '"' || current === '\'') {
+        const literal = extractJsStringLiteral(source, cursor);
+        if (!literal) {
+          cursor += 1;
+          continue;
+        }
+        const decoded = decodeJsStringLiteral(literal);
+        if (decoded !== null) {
+          try {
+            return JSON.parse(decoded);
+          } catch (error) {
+            // fall through and continue scanning after the literal
+          }
+        }
+        cursor += literal.length;
+        continue;
+      }
+
+      if (source.startsWith('JSON.parse', cursor)) {
+        const openParenIndex = source.indexOf('(', cursor);
+        if (openParenIndex === -1) {
+          cursor += 'JSON.parse'.length;
+          continue;
+        }
+
+        let argumentIndex = openParenIndex + 1;
+        while (argumentIndex < source.length && /\s/.test(source[argumentIndex])) {
+          argumentIndex += 1;
+        }
+
+        if (argumentIndex >= source.length) {
+          cursor = openParenIndex + 1;
+          continue;
+        }
+
+        const argumentStart = source[argumentIndex];
+        if (argumentStart === '"' || argumentStart === '\'') {
+          const literal = extractJsStringLiteral(source, argumentIndex);
+          if (!literal) {
+            cursor = argumentIndex + 1;
+            continue;
+          }
+          const decoded = decodeJsStringLiteral(literal);
+          if (decoded !== null) {
+            try {
+              return JSON.parse(decoded);
+            } catch (error) {
+              // continue scanning when the literal is not valid JSON
+            }
+          }
+          cursor = argumentIndex + literal.length;
+          continue;
+        }
+
+        cursor = argumentIndex + 1;
+        continue;
+      }
+
+      if (/[A-Za-z0-9_$.[\]]/.test(current)) {
+        cursor = advancePastIdentifierChain(source, cursor);
+        continue;
+      }
+
+      if (current === '|' || current === '&' || current === '?' || current === ':' || current === '+' || current === '-') {
+        cursor += 1;
+        continue;
+      }
+
+      cursor += 1;
+    }
+
+    searchIndex = index + marker.length;
+  }
+
+  return null;
+}
+
+function advancePastIdentifierChain(source, startIndex) {
+  let cursor = startIndex;
+  while (cursor < source.length) {
+    const character = source[cursor];
+    if (/[A-Za-z0-9_$]/.test(character)) {
+      cursor += 1;
+      continue;
+    }
+
+    if (character === '.') {
+      cursor += 1;
+      continue;
+    }
+
+    if (character === '[') {
+      cursor += 1;
+      while (cursor < source.length && /\s/.test(source[cursor])) {
+        cursor += 1;
+      }
+
+      if (cursor >= source.length) {
+        return cursor;
+      }
+
+      const bracketStart = source[cursor];
+      if (bracketStart === '"' || bracketStart === '\'') {
+        const literal = extractJsStringLiteral(source, cursor);
+        if (!literal) {
+          return cursor;
+        }
+        cursor += literal.length;
+        while (cursor < source.length && /\s/.test(source[cursor])) {
+          cursor += 1;
+        }
+        if (source[cursor] === ']') {
+          cursor += 1;
+          continue;
+        }
+        return cursor;
+      }
+
+      while (cursor < source.length && source[cursor] !== ']') {
+        cursor += 1;
+      }
+      if (source[cursor] === ']') {
+        cursor += 1;
+      }
+      continue;
+    }
+
+    if (character === ']') {
+      cursor += 1;
+      continue;
+    }
+
+    break;
+  }
+
+  return cursor;
+}
+
+function extractBalancedJson(source, startIndex) {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = startIndex; index < source.length; index += 1) {
+    const character = source[index];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (character === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) {
+      continue;
+    }
+
+    if (character === '{') {
+      depth += 1;
+    } else if (character === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(startIndex, index + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+function extractJsStringLiteral(source, startIndex) {
+  const quote = source[startIndex];
+  let cursor = startIndex + 1;
+  let escaped = false;
+
+  while (cursor < source.length) {
+    const character = source[cursor];
+    if (escaped) {
+      escaped = false;
+    } else if (character === '\\') {
+      escaped = true;
+    } else if (character === quote) {
+      return source.slice(startIndex, cursor + 1);
+    }
+    cursor += 1;
+  }
+
+  return null;
+}
+
+function decodeJsStringLiteral(literal) {
+  if (typeof literal !== 'string' || literal.length < 2) {
+    return null;
+  }
+
+  const quote = literal[0];
+  if ((quote !== '"' && quote !== '\'') || literal[literal.length - 1] !== quote) {
+    return null;
+  }
+
+  let result = '';
+  for (let index = 1; index < literal.length - 1; index += 1) {
+    const character = literal[index];
+    if (character === '\\') {
+      index += 1;
+      if (index >= literal.length - 1) {
+        break;
+      }
+
+      const next = literal[index];
+      switch (next) {
+        case 'n':
+          result += '\n';
+          break;
+        case 'r':
+          result += '\r';
+          break;
+        case 't':
+          result += '\t';
+          break;
+        case 'b':
+          result += '\b';
+          break;
+        case 'f':
+          result += '\f';
+          break;
+        case 'v':
+          result += '\v';
+          break;
+        case '0':
+          result += '\0';
+          break;
+        case '\\':
+          result += '\\';
+          break;
+        case '\'':
+          result += '\'';
+          break;
+        case '"':
+          result += '"';
+          break;
+        case 'x': {
+          const hex = literal.slice(index + 1, index + 3);
+          if (/^[0-9A-Fa-f]{2}$/.test(hex)) {
+            result += String.fromCharCode(Number.parseInt(hex, 16));
+            index += 2;
+          } else {
+            result += next;
+          }
+          break;
+        }
+        case 'u': {
+          const hex = literal.slice(index + 1, index + 5);
+          if (/^[0-9A-Fa-f]{4}$/.test(hex)) {
+            result += String.fromCharCode(Number.parseInt(hex, 16));
+            index += 4;
+          } else {
+            result += next;
+          }
+          break;
+        }
+        default:
+          result += next;
+          break;
+      }
+    } else {
+      result += character;
+    }
+  }
+
+  return result;
+}
+
+function selectBestCaptionTrack(playerResponse) {
+  const tracks = playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+  if (!Array.isArray(tracks) || tracks.length === 0) {
+    return null;
+  }
+
+  const viableTracks = tracks.filter((track) => track && typeof track.baseUrl === 'string' && track.baseUrl.trim().length > 0);
+  if (viableTracks.length === 0) {
+    return null;
+  }
+
+  const scored = viableTracks
+    .map((track, index) => ({ track, index, score: scoreCaptionTrack(track) }))
+    .sort((a, b) => {
+      if (b.score !== a.score) {
+        return b.score - a.score;
+      }
+      return a.index - b.index;
+    });
+
+  return scored[0]?.track ?? null;
+}
+
+function scoreCaptionTrack(track) {
+  if (!track || typeof track !== 'object') {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  let score = 0;
+  const languageCode = typeof track.languageCode === 'string' ? track.languageCode.toLowerCase() : '';
+  const vssId = typeof track.vssId === 'string' ? track.vssId.toLowerCase() : '';
+  const trackKind = typeof track.kind === 'string' ? track.kind.toLowerCase() : '';
+
+  if (languageCode === 'en') {
+    score += 30;
+  } else if (languageCode.startsWith('en')) {
+    score += 25;
+  } else if (languageCode) {
+    score += 10;
+  }
+
+  if (!trackKind) {
+    score += 5;
+  } else if (trackKind === 'asr') {
+    score -= 5;
+  }
+
+  if (vssId.startsWith('a.')) {
+    score -= 2;
+  }
+
+  if (track.isTranslatable) {
+    score += 1;
+  }
+
+  return score;
+}
+
+function buildTimedTextRequestUrl(baseUrl) {
+  if (typeof baseUrl !== 'string' || !baseUrl.trim()) {
+    return null;
+  }
+
+  try {
+    const url = new URL(baseUrl);
+    url.searchParams.set('fmt', 'json3');
+    return url.toString();
+  } catch (error) {
+    return null;
+  }
+}
+
+async function fetchTimedTextJson(requestUrl) {
+  if (typeof requestUrl !== 'string' || !requestUrl) {
+    return null;
+  }
+
+  const response = await fetch(requestUrl, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`Timed text request failed with status ${response.status}`);
+  }
+
+  const rawText = await response.text();
+  const sanitized = stripXssiPrefix(rawText).trim();
+  if (!sanitized) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(sanitized);
+  } catch (error) {
+    throw new Error('Unable to parse timed text response as JSON.');
+  }
+}
+
+function stripXssiPrefix(text) {
+  if (typeof text !== 'string') {
+    return '';
+  }
+  return text.replace(/^\)\]\}'\s*/u, '');
 }
 
 function extractVideoIdFromUrl(videoUrl) {

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
     "storage"
   ],
   "host_permissions": [
-    "https://www.youtube.com/*",
+    "https://*.youtube.com/*",
     "https://chatgpt.com/*",
     "https://glasp.co/*"
   ],

--- a/test/extractPlayerResponseFromWatchHtml.test.js
+++ b/test/extractPlayerResponseFromWatchHtml.test.js
@@ -1,0 +1,78 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function createChromeStub() {
+  return {
+    runtime: { onMessage: { addListener: () => {} } },
+    tabs: {
+      onUpdated: { addListener: () => {}, removeListener: () => {} },
+      onRemoved: { addListener: () => {}, removeListener: () => {} },
+      create: async () => ({}),
+      remove: async () => {},
+      get: async () => ({})
+    },
+    storage: {
+      session: {
+        async get() {
+          return {};
+        },
+        async set() {},
+        async remove() {}
+      },
+      local: {
+        async get() {
+          return {};
+        },
+        async set() {},
+        async remove() {}
+      }
+    },
+    scripting: {
+      async executeScript() {
+        return [{ result: '' }];
+      }
+    }
+  };
+}
+
+if (typeof global.chrome === 'undefined') {
+  global.chrome = createChromeStub();
+}
+
+const { extractPlayerResponseFromWatchHtml, isConsentInterstitialHtml } = require('../background.js');
+
+test('extractPlayerResponseFromWatchHtml parses assignments with fallback expressions', () => {
+  const fixturePath = path.join(__dirname, 'fixtures', 'watch-with-fallback.html');
+  const html = fs.readFileSync(fixturePath, 'utf8');
+
+  const playerResponse = extractPlayerResponseFromWatchHtml(html);
+
+  assert.ok(playerResponse, 'Expected a player response object');
+  assert.deepStrictEqual(
+    playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks?.[0]?.baseUrl,
+    'https://example.com/captions'
+  );
+});
+
+test('extractPlayerResponseFromWatchHtml skips non-JSON assignments and continues scanning', () => {
+  const fixturePath = path.join(__dirname, 'fixtures', 'watch-with-multi-assignments.html');
+  const html = fs.readFileSync(fixturePath, 'utf8');
+
+  const playerResponse = extractPlayerResponseFromWatchHtml(html);
+
+  assert.ok(playerResponse, 'Expected a player response object');
+  assert.deepStrictEqual(
+    playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks?.[0]?.baseUrl,
+    'https://example.com/alt-captions'
+  );
+});
+
+test('isConsentInterstitialHtml identifies consent interstitial markup', () => {
+  const fixturePath = path.join(__dirname, 'fixtures', 'watch-consent.html');
+  const html = fs.readFileSync(fixturePath, 'utf8');
+
+  assert.equal(isConsentInterstitialHtml(html), true);
+  assert.equal(extractPlayerResponseFromWatchHtml(html), null);
+});

--- a/test/fixtures/watch-consent.html
+++ b/test/fixtures/watch-consent.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Before you continue to YouTube</title>
+  </head>
+  <body>
+    <h1>Before you continue to YouTube</h1>
+    <p>We use cookies and data to deliver and maintain Google services.</p>
+    <form action="https://consent.youtube.com/save" method="post">
+      <input type="hidden" name="continue" value="https://www.youtube.com/watch?v=dQw4w9WgXcQ" />
+      <button type="submit">Accept all</button>
+    </form>
+  </body>
+</html>

--- a/test/fixtures/watch-with-fallback.html
+++ b/test/fixtures/watch-with-fallback.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YouTube</title>
+  </head>
+  <body>
+    <script>
+      var ytInitialPlayerResponse = window.ytInitialPlayerResponse || {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://example.com/captions"}]}}};
+    </script>
+  </body>
+</html>

--- a/test/fixtures/watch-with-multi-assignments.html
+++ b/test/fixtures/watch-with-multi-assignments.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>YouTube</title>
+  </head>
+  <body>
+    <script>
+      var ytInitialPlayerResponse = window.ytInitialPlayerResponse || null;
+      if (!ytInitialPlayerResponse) {
+        ytInitialPlayerResponse = this.ytInitialPlayerResponse || void 0;
+      }
+      this.ytInitialPlayerResponse = window["ytInitialPlayerResponse"] || {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https://example.com/alt-captions"}]}}};
+    </script>
+  </body>
+</html>

--- a/test/parseTranscriptFromReaderText.test.js
+++ b/test/parseTranscriptFromReaderText.test.js
@@ -1,0 +1,151 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function createChromeStub() {
+  return {
+    runtime: { onMessage: { addListener: () => {} } },
+    tabs: {
+      onUpdated: { addListener: () => {}, removeListener: () => {} },
+      onRemoved: { addListener: () => {}, removeListener: () => {} },
+      create: async () => ({}),
+      remove: async () => {},
+      get: async () => ({})
+    },
+    storage: {
+      session: {
+        async get() {
+          return {};
+        },
+        async set() {},
+        async remove() {}
+      },
+      local: {
+        async get() {
+          return {};
+        },
+        async set() {},
+        async remove() {}
+      }
+    },
+    scripting: {
+      async executeScript() {
+        return [{ result: '' }];
+      }
+    }
+  };
+}
+
+if (typeof global.chrome === 'undefined') {
+  global.chrome = createChromeStub();
+}
+
+const {
+  parseTranscriptFromReaderText,
+  stripLeadingGlaspMetadataLines
+} = require('../background.js');
+
+test('stripLeadingGlaspMetadataLines removes Glasp header metadata', () => {
+  const lines = [
+    '#philosophaire',
+    'September 18, 2025',
+    'by',
+    'Philosophaire',
+    '#philosophaires',
+    'Share Video',
+    'Download .srt',
+    'Copy',
+    'As you get older, you start seeing things differently.'
+  ];
+
+  const stripped = stripLeadingGlaspMetadataLines(lines);
+
+  assert.deepStrictEqual(stripped, [
+    'As you get older, you start seeing things differently.'
+  ]);
+});
+
+test('parseTranscriptFromReaderText drops Glasp metadata headers', () => {
+  const pageText = [
+    'Glasp Reader',
+    'YouTube Transcript & Summary',
+    '#philosophaire',
+    'September 18, 2025',
+    'by',
+    'Philosophaire',
+    'YouTube video player',
+    '#philosophaires',
+    'Transcripts',
+    'Share Video',
+    'Download .srt',
+    'Copy Transcript',
+    'Summarize Transcript',
+    'English (auto-generated)',
+    'As you get older, you start seeing things differently.',
+    'You notice how people affect your peace.'
+  ].join('\n');
+
+  const parsed = parseTranscriptFromReaderText(pageText);
+
+  assert.strictEqual(
+    parsed,
+    [
+      'As you get older, you start seeing things differently.',
+      'You notice how people affect your peace.'
+    ].join('\n')
+  );
+});
+
+test('stripLeadingGlaspMetadataLines removes glued metadata tokens', () => {
+  const lines = [
+    '#creatorShare VideoDownload .srtCopy',
+    'September 19, 2025',
+    'by Creator Name',
+    'Opening line of the transcript.'
+  ];
+
+  const stripped = stripLeadingGlaspMetadataLines(lines);
+
+  assert.deepStrictEqual(stripped, ['Opening line of the transcript.']);
+});
+
+test('stripLeadingGlaspMetadataLines trims fused metadata and preserves transcript', () => {
+  const lines = [
+    '#philosophaireSeptember 23, 2025#philosophairesShare VideoDownload .srtCopyAs you get older, you start seeing things differently.'
+  ];
+
+  const stripped = stripLeadingGlaspMetadataLines(lines);
+
+  assert.deepStrictEqual(stripped, [
+    'As you get older, you start seeing things differently.'
+  ]);
+});
+
+test('stripLeadingGlaspMetadataLines removes fused title/date metadata before controls', () => {
+  const lines = [
+    'Solve Any Problem With This 1 Simple MethodApril 27, 2025byGrindBuddySolve Any Problem With This 1 Simple MethodsShare VideoDownload .srtCopygo into the silence go and sit down quietly.'
+  ];
+
+  const stripped = stripLeadingGlaspMetadataLines(lines);
+
+  assert.deepStrictEqual(stripped, ['go into the silence go and sit down quietly.']);
+});
+
+test('parseTranscriptFromReaderText handles fused metadata header text', () => {
+  const pageText = [
+    'Glasp Reader',
+    'YouTube Transcript & Summary',
+    '#philosophaireSeptember 23, 2025#philosophairesShare VideoDownload .srtCopy',
+    'As you get older, you start seeing things differently.',
+    'You notice how people affect your peace.'
+  ].join('\n');
+
+  const parsed = parseTranscriptFromReaderText(pageText);
+
+  assert.strictEqual(
+    parsed,
+    [
+      'As you get older, you start seeing things differently.',
+      'You notice how people affect your peace.'
+    ].join('\n')
+  );
+});


### PR DESCRIPTION
## Summary
- allow the Glasp metadata stripper to trim any fused control labels such as "Share Video", "Download .srt", or "Copy" even when a video title and date precede them on the same line
- ensure fallback transcripts drop everything before the control block so only spoken dialogue remains
- add regression coverage for a title/date block glued to Glasp controls to confirm the helper returns the opening narration

## Testing
- node test/parseTranscriptFromReaderText.test.js
- node test/extractPlayerResponseFromWatchHtml.test.js
- node test/sanitizeTranscriptForPrompt.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d2f8d0092883209e74c5edb9e47fd3